### PR TITLE
FIX: inputs secrets

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -3,10 +3,13 @@ description: "Check documentation style using Vale"
 
 inputs:
   vale-config:
-    description: 'Path to the Vale configuration file'
-    default: 'doc/.vale.ini'
+    description: "Path to the Vale configuration file"
+    default: "doc/.vale.ini"
     required: false
     type: string
+  token:
+    description: "Required token for Vale commenter"
+    required: true
 
 runs:
   using: "composite"
@@ -18,7 +21,7 @@ runs:
     - name: "Run Vale"
       uses: errata-ai/vale-action@reviewdog
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       with:
         files: doc
         reporter: github-pr-check


### PR DESCRIPTION
This pull-request avoids having all workflows inside the `.github/workflows` dir by forcing users to pass tokens and secrets to the actions.

It does not introduce security vulnerabilities as the tokens are executed at runtime and not store in this repository.