### PR TITLE
FIX: doc-build input names

### DIFF
--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: ''
     required: false
     type: string
-  requies_xvfb:
+  requires-xvfb:
       description: 'Whether to use X Virtual Frame Buffer for rendering the docs'
       default: false
       required: false
@@ -52,7 +52,7 @@ runs:
 
     - name: "Install X Virtual Frame Buffer"
       shell: bash
-      if: inputs.requies_xvfb
+      if: inputs.requires-xvfb
       run: |
         sudo apt-get install xvfb
 
@@ -82,7 +82,7 @@ runs:
       run: python -m pip install .[doc]
     
     - name: "Build HTML, PDF, and JSON documentation"
-      if: inputs.requies_xvfb
+      if: inputs.requires-xvfb == false
       shell: bash
       run: |
         make -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
@@ -90,7 +90,7 @@ runs:
         make -C doc json SPHINXOPTS="${{ inputs.sphinxopts }}"
 
     - name: "Build HTML and JSON documentation using xvfb"
-      if: inputs.requies_xvfb
+      if: inputs.requires-xvfb == true
       shell: bash
       run: |
         xvfb-run make -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"


### PR DESCRIPTION
As per [failing actions in ansys-templates](https://github.com/ansys/ansys-templates/actions/runs/3329549652/jobs/5506934463), it looks like the logic behind using Xvfb is not properly working.

This pull-request solves for some syntax errors and uses explicit conditional examples.