### PR TITLE
CI: test against latest SHA

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,6 +10,7 @@ on:
 env:
   MAIN_PYTHON_VERSION: '3.10'
   CNAME: 'actions.docs.pyansys.com'
+  code-style-action: "pyansys/actions/code-style@${{ github.sha }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -94,7 +95,7 @@ jobs:
     needs: commenter
     steps:
       - name: "Run code style checks"
-        uses: pyansys/actions/code-style@main
+        uses: ${{ env.code-style-action }}
 
   doc-style:
     name: "Doc style"


### PR DESCRIPTION
This pull request partially addresses #15. Some of the actions defined in this repository are used in its own CI/CD:

* The code style action
* The doc style action
* The doc build action
* The doc deploy dev action
* The doc deploy stable action

This pull request imposes to use the actions as soon as those get modified. This is achieved by using the latest SHA of the commit triggering the actions.