### PR TITLE
FIX: typo in Build library action documentation

### DIFF
--- a/doc/source/build-actions/index.rst
+++ b/doc/source/build-actions/index.rst
@@ -25,7 +25,7 @@ Here is a code sample for using this action:
         - name: "Build library source and wheel artifacts"
           uses: pyansys/actions/build-library@main
           with:
-            library-name: "ansys-<product>-<library"
+            library-name: "ansys-<product>-<library>"
 
 
 Build C-extension library action


### PR DESCRIPTION
Fix minor typo in build library action doc. 

Character ">" was missing at the end in line 28.