### PR TITLE
FEAT: add private _setup-python action and force cache usage

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
   
     - name: "Set up Python"
-      uses: actions/setup-python@v4
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ env.MAIN_PYTHON_VERSION }}
 

--- a/_setup-python/action.yml
+++ b/_setup-python/action.yml
@@ -1,0 +1,19 @@
+name: "Set up Python"
+description: "Set up Python and enables cache"
+
+inputs:
+  python-version:
+    description: 'Desired Python version'
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+  
+    - name: "Set up Python"
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'

--- a/build-ci-wheels/action.yml
+++ b/build-ci-wheels/action.yml
@@ -35,8 +35,8 @@ runs:
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
     
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v2
+    - name: "Set up Python ${{ inputs.python-version }}"
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
    

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: actions/checkout@v3
   
     - name: "Set up Python"
-      uses: actions/setup-python@v4.2.0
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/checkout@v3
   
     - name: "Set up Python ${{ inputs.python-version }}"
-      uses: actions/setup-python@v4
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/checkout@v3
   
     - name: "Set up Python"
-      uses: actions/setup-python@v4.2.0
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
   

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -36,7 +36,7 @@ runs:
       uses: actions/checkout@v3
   
     - name: "Set up Python"
-      uses: actions/setup-python@v4.2.0
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -1,4 +1,3 @@
-
 inputs:
   cname:
     description: 'The canonical name of the documentation website'
@@ -51,7 +50,7 @@ runs:
         echo "VERSION=$major.$minor" >> $GITHUB_ENV
 
     - name: "Download the HTML documentation artifact in release/${{ github.ref_name }}"
-      uses: actions/download-artifact@v3
+      uses: pyansys/actions/_setup-python@main
       with:
         name: documentation-html
         path: release/${{ env.VERSION }}

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -35,7 +35,7 @@ runs:
       uses: actions/checkout@v3
   
     - name: "Set up Python"
-      uses: actions/setup-python@v4.2.0
+      uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
This pull-request solves #56 by adding a "private" action for setting up Python. This action is then reused across all the different actions in the repository.