### PR TITLE
FEAT: publish all artifacts during GitHub release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -243,28 +243,41 @@ jobs:
   release-gitub:
     name: "Release to GitHub"
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [doc-deploy-stable, tests-release-pypi-test]
     steps:
 
-      - name: "Download {{ inputs.library-name }} HTML documentation"
-        uses: actions/download-artifact@v3
-        with:
-          name: documentation-html
-          path: documentation-html
+    - name: "Download HTML documentation"
+      uses: actions/download-artifact@v3
+      with:
+        name: documentation-html
+        path: documentation-html
 
-      - name: "Download {{ inputs.library-name }} PDF documentation"
-        uses: actions/download-artifact@v3
-        with:
-          name: documentation-pdf
-          path: documentation-pdf
+    - name: "Zip HTML documentation"
+      uses: vimtor/action-zip@v1
+      with:
+        files: documentation-html
+        dest: documentation-html.zip
 
-      - name: "Display the structure of downloaded files"
-        run: ls -R
+    - name: "Download PDF documentation"
+      uses: actions/download-artifact@v3
+      with:
+        name: documentation-pdf
+        path: documentation-pdf
 
-      - name: "Release to GitHub"
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            documentation-html/*.html
-            documentation-pdf/*.pdf
+    - name: "Zip PDF documentation"
+      uses: vimtor/action-zip@v1
+      with:
+        files: documentation-pdf
+        dest: documentation-pdf.zip
+
+    - name: "Display the structure of downloaded files"
+      shell: bash
+      run: ls -R
+
+    - name: "Release to GitHub"
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          documentation-html.zip
+          documentation-pdf.zip

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -35,6 +35,30 @@ runs:
         name: documentation-pdf
         path: documentation-pdf
 
+    - name: "Zip PDF documentation"
+      uses: vimtor/action-zip@v1
+      with:
+        files: documentation-pdf
+        dest: documentation-pdf.zip
+
+    - name: "Download other artifacts (wheelhouse, cibuildwheel...)"
+      uses: actions/download-artifact@v3
+      with:
+        path: other-artifacts
+
+    - name: "Remove duplicated artifacts"
+      shell: bash
+      run: |
+        rm -rf other-artifacts/documentation-html
+        rm -rf other-artifacts/documentation-pdf
+        rm -rf other-artifacts/${{ inputs.library-name }}-artifacts
+
+    - name: "Zip other artifacts"
+      uses: vimtor/action-zip@v1
+      with:
+        files: other-artifacts
+        dest: other-artifacts.zip
+
     - name: "Display the structure of downloaded files"
       shell: bash
       run: ls -R
@@ -46,4 +70,5 @@ runs:
           ${{ inputs.library-name }}/*.whl
           ${{ inputs.library-name }}/*.tar.gz
           documentation-html.zip
-          documentation-pdf/*.pdf
+          documentation-pdf.zip
+          other-artifacts.zip

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -53,12 +53,6 @@ runs:
         rm -rf other-artifacts/documentation-pdf
         rm -rf other-artifacts/${{ inputs.library-name }}-artifacts
 
-    - name: "Zip other artifacts"
-      uses: vimtor/action-zip@v1
-      with:
-        files: other-artifacts
-        dest: other-artifacts.zip
-
     - name: "Display the structure of downloaded files"
       shell: bash
       run: ls -R
@@ -71,4 +65,4 @@ runs:
           ${{ inputs.library-name }}/*.tar.gz
           documentation-html.zip
           documentation-pdf.zip
-          other-artifacts/**/*-wheelhouse-*.zip
+          other-artifacts/**/*-wheelhouse-*.whl

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -65,4 +65,4 @@ runs:
           ${{ inputs.library-name }}/*.tar.gz
           documentation-html.zip
           documentation-pdf.zip
-          other-artifacts/**/*-wheelhouse-*.whl
+          other-artifacts/**/*-wheelhouse-*.zip

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -71,4 +71,4 @@ runs:
           ${{ inputs.library-name }}/*.tar.gz
           documentation-html.zip
           documentation-pdf.zip
-          other-artifacts.zip
+          other-artifacts/**/*-wheelhouse-*.zip


### PR DESCRIPTION
Solve #57 by publishing during a GitHub release all generated artifacts.