### PR TITLE
FIX: secrets usage in doc-deploy-to-repo

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -159,8 +159,10 @@ jobs:
         if: github.event_name == 'push'
         uses: pyansys/actions/doc-deploy-to-repo@main
         with:
-            cname: ${{ env.CNAME }}
-            repository: "pyansys/actions"
+          cname: ${{ env.CNAME }}
+          repository: "pyansys/actions"
+          bot-id: ${{ secrets.BOT_APPLICATION_ID }}
+          bot-token: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
 
   doc-deploy-dev:
     name: "Deploy developers documentation"

--- a/doc-deploy-to-repo/action.yml
+++ b/doc-deploy-to-repo/action.yml
@@ -12,13 +12,11 @@ inputs:
     type: string
   bot-id:
     description: "Required application ID for documentation deployment"
-    default: ${{ secrets.BOT_APPLICATION_ID }}
-    required: false
+    required: true
     type: string
   bot-token:
     description: "Required application token for documentation deployment"
-    default: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
-    required: false
+    required: true
     type: string
 
 runs:


### PR DESCRIPTION
I just remembered that secrets cannot be used in reusable actions. They need to be passed as arguments. This solves the latest CI failures related with this issue.