### PR TITLE
DOC: fix example bug

### DIFF
--- a/doc/source/tests-actions/index.rst
+++ b/doc/source/tests-actions/index.rst
@@ -21,7 +21,7 @@ Here is a code sample for using this action:
 
     tests:
       name: "Test library"
-      runs-on: ubuntu-latest
+      runs-on: ${{ matrix.os }}
       strategy:
          matrix:
              os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Make sure example takes advantage of `matrix`. I will cherry-pick this into the `release/1.0`, so it is fixed in the documentation of that branch too.