### PR TITLE
FIX: do not use cache in doc-deploy-stable

### DIFF
--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -20,11 +20,6 @@ inputs:
     default: '3.10'
     required: false
     type: string
-  use-python-cache:
-    description: 'Whether to use Python cache or not. Requires a pyproject.toml file.'
-    required: false
-    default: true
-    type: boolean
 
 runs:
   using: "composite"
@@ -67,7 +62,7 @@ runs:
       uses: pyansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
-        use-cache: ${{ inputs.use-python-cache }}
+        use-cache: false
 
     - name: "Install system dependencies for updating version table"
       shell: bash


### PR DESCRIPTION
As per [pygeomemtry failing actions](https://github.com/pyansys/pygeometry/actions/runs/3487427530/jobs/5835475424). This will be cherry-picked to the release/1.0. I will also move the v1 tag.