### PR TITLE
Update zip action to v1.1

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -252,7 +252,7 @@ jobs:
         path: documentation-html
 
     - name: "Zip HTML documentation"
-      uses: vimtor/action-zip@v1
+      uses: vimtor/action-zip@v1.1
       with:
         files: documentation-html
         dest: documentation-html.zip
@@ -264,7 +264,7 @@ jobs:
         path: documentation-pdf
 
     - name: "Zip PDF documentation"
-      uses: vimtor/action-zip@v1
+      uses: vimtor/action-zip@v1.1
       with:
         files: documentation-pdf
         dest: documentation-pdf.zip

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -56,7 +56,7 @@ runs:
       run: python -m pip wheel . -w wheelhouse
 
     - name: "Zip wheelhouse"
-      uses: vimtor/action-zip@v1
+      uses: vimtor/action-zip@v1.1
       with:
         files: wheelhouse
         dest: ${{ inputs.library-name }}-v${{ env.library_version }}-wheelhouse-${{ inputs.operating-system }}-${{ inputs.python-version }}.zip

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -24,7 +24,7 @@ runs:
         path: documentation-html
 
     - name: "Zip HTML documentation"
-      uses: vimtor/action-zip@v1
+      uses: vimtor/action-zip@v1.1
       with:
         files: documentation-html
         dest: documentation-html.zip
@@ -36,7 +36,7 @@ runs:
         path: documentation-pdf
 
     - name: "Zip PDF documentation"
-      uses: vimtor/action-zip@v1
+      uses: vimtor/action-zip@v1.1
       with:
         files: documentation-pdf
         dest: documentation-pdf.zip


### PR DESCRIPTION
Zip action was updated over the weekend to solve issues with Node JS 12 version. Now it is using Node JS 16. However, tag ``@v1`` was not updated when releasing and for making use of this new version we need to add the minor version to the call. Dependabot won't update it automatically either since we are only specifying the major version.