### PR TITLE
FEAT: enable outdated versions announcement logic

### DIFF
--- a/scripts/version_mapper.py
+++ b/scripts/version_mapper.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 
@@ -93,20 +94,18 @@ def update_switch_version_file(
         json.dump(new_content, switcher_file, indent=4)
 
     # Use the latest stable verion for formatting the announcement
-    with open(annoucement_filename, "r") as announcement_file:
+    with open(f"release/{annoucement_filename}", "r") as announcement_file:
         content = announcement_file.read()
         announcement_content = content.format(version=latest_stable_version)
 
     # Include the announcement in all available release folders. Note that
     # these are still accessible even if they are not included in the dropdown.
-    release_folders = [path for path in Path("./").iterdir() if path.is_dir()]
-    for release_folder in release_folders:
-        # Skip the latest stable version
-        if str(release_folder) == latest_stable_version:
-            continue
-
+    old_release_folders = [
+        path for path in Path("./").iterdir() if re.match("^[0-9]+.[0-9]+$", path.name)
+    ]
+    for release_folder in old_release_folders:
         # Create an 'announcement.html' file within each one of the old versions
-        with open(f"{str(release_folder)}/announcement.html", "w") as file:
+        with open(f"release/{release_folder.name}/announcement.html", "w") as file:
             file.write(announcement_content)
 
 

--- a/scripts/version_mapper.py
+++ b/scripts/version_mapper.py
@@ -20,7 +20,7 @@ def sort_versions_descending(versions_list):
 
 
 def update_switch_version_file(
-    json_filename, new_version, cname, render_last, annoucement_filename
+    json_filename, new_version, cname, render_last, announcement_filename
 ):
     """Add new version number and associated URL to JSON file.
 
@@ -34,7 +34,7 @@ def update_switch_version_file(
         The canonical name of the project's documentation website.
     render_last : int
         The number of stable releases to be shown in the version switcher.
-    announcement_filename : str
+    announcement_file : str
         Name of the HTML file controlling the outdated version announcement.
 
     """
@@ -94,7 +94,7 @@ def update_switch_version_file(
         json.dump(new_content, switcher_file, indent=4)
 
     # Use the latest stable verion for formatting the announcement
-    with open(f"release/{annoucement_filename}", "r") as announcement_file:
+    with open(f"release/{announcement_filename}", "r") as announcement_file:
         content = announcement_file.read()
         announcement_content = content.format(version=latest_stable_version)
 

--- a/tests/tests_scripts/release/announcement.html
+++ b/tests/tests_scripts/release/announcement.html
@@ -1,0 +1,1 @@
+<p>You are not reading the most recent version of this documentation. Latest stable release is <a href="https://actions.pyansys.com/release/{version}">{version}</a></p>.

--- a/tests/tests_scripts/test_version_mapper.py
+++ b/tests/tests_scripts/test_version_mapper.py
@@ -31,10 +31,11 @@ def test_update_switch_version_file(new_version, render_last, cname):
 
     # Execute the logic behind the version update script
     update_switch_version_file(
-        filename="versions.json",
+        json_filename="versions.json",
         new_version=new_version,
         cname=cname,
         render_last=render_last,
+        annoucement_filename="announcement.html",
     )
 
     with open("release/versions.json", "r") as switcher_file:

--- a/tests/tests_scripts/test_version_mapper.py
+++ b/tests/tests_scripts/test_version_mapper.py
@@ -35,7 +35,7 @@ def test_update_switch_version_file(new_version, render_last, cname):
         new_version=new_version,
         cname=cname,
         render_last=render_last,
-        annoucement_filename="announcement.html",
+        announcement_filename="announcement.html",
     )
 
     with open("release/versions.json", "r") as switcher_file:


### PR DESCRIPTION
Fix #80.

Repositories should implement an `announcement.html` template in their `gh-pages` branch and within the `release/` folder.

The content of the `announcement.html` should look like:

```html
<p>You are not reading the most recent version of this documentation. Latest stable release is <a href="https://actions.pyansys.com/release/{version}">{version}</a></p>.
```

This way, the version script can format that template to the desired version.