### PR TITLE
Rename namespace for argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ cython_debug/
 
 # Visual Studio
 .vs/
+.vscode/
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 

--- a/scripts/version_mapper.py
+++ b/scripts/version_mapper.py
@@ -156,7 +156,7 @@ def main():
         args.new_version,
         args.cname,
         args.render_last,
-        args.announcement_file,
+        args.announcement_filename,
     )
 
 


### PR DESCRIPTION
Namespace object has no attribute 'announcement_file', which will create error. Resolves the above.