### PR TITLE
FIX: ignore missing announcement.html

### DIFF
--- a/scripts/version_mapper.py
+++ b/scripts/version_mapper.py
@@ -94,9 +94,13 @@ def update_switch_version_file(
         json.dump(new_content, switcher_file, indent=4)
 
     # Use the latest stable verion for formatting the announcement
-    with open(f"release/{announcement_filename}", "r") as announcement_file:
-        content = announcement_file.read()
-        announcement_content = content.format(version=latest_stable_version)
+    try:
+        with open(f"release/{announcement_filename}", "r") as announcement_file:
+            content = announcement_file.read()
+            announcement_content = content.format(version=latest_stable_version)
+    except FileNotFoundError:
+        # If no announcement file has been found, terminate this script
+        return
 
     # Include the announcement in all available release folders. Note that
     # these are still accessible even if they are not included in the dropdown.


### PR DESCRIPTION
The "version_mapper.py" script gets downloaded from "main" branch. The latest changes introduced in #84 were being used, thus, by the "v1" branch.

This changes check whether the announcement file exists or not. If it is not present, the script terminates and forgets about the announcement.