### PR TITLE
Add an input for the render last version for multiple documentation in workflow

### DIFF
--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -20,6 +20,11 @@ inputs:
     default: '3.10'
     required: false
     type: string
+  render-last:
+    description: 'Number of last versions to be rendered in multi-doc.'
+    default: '3'
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -102,7 +107,7 @@ runs:
           --cname ${{ inputs.cname }} \
           --json_filename ${{ inputs.version-config }} \
           --new_version ${{ env.VERSION }} \
-          --render_last 3
+          --render_last ${{ inputs.render-last }}
         # Remove the script to avoid Git tracking it
         rm -rf version_mapper.py
 


### PR DESCRIPTION
User should able to decide the number of versions to get rendered in multi-doc. Fix #99 