### PR TITLE
FIX: scripts version

### DIFF
--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -97,7 +97,7 @@ runs:
       if: env.ACCEPTED_FORMAT == 'true'
       shell: bash
       run: |
-        curl https://raw.githubusercontent.com/pyansys/actions/release/${{ env.VERSION }}/scripts/version_mapper.py -o version_mapper.py
+        curl https://raw.githubusercontent.com/pyansys/actions/main/scripts/version_mapper.py -o version_mapper.py
 
     - name: "Update the version JSON file"
       if: env.ACCEPTED_FORMAT == 'true'


### PR DESCRIPTION
Reverting the changes made in #111. The version used in that PR was the one from the library using the actions, not the one from the actions. There is not way for the action to know where version they belong to when executed from the CI/CD of a third party repo. I bet the best way to go is to manually change this every time we do a new stable release.