### PR TITLE
FIX: clear gh-pages branch before pushing

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -80,6 +80,13 @@ runs:
         sed -i "s|var-url|$url|g" index.html
         cat index.html
 
+    - name: "Clear unnecessary gh-pages files and directories"
+      shell: bash
+      run: |
+        shopt -s extglob
+        rm -rf -v !("index.html"|"release"|"dev"|"CNAME"|".nojekyll")
+        ls -R
+
     - name: "Commit new changes (if required)"
       shell: bash
       run: |

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -117,6 +117,13 @@ runs:
         # Remove the script to avoid Git tracking it
         rm -rf version_mapper.py index.html
 
+    - name: "Clear unnecessary gh-pages files and directories"
+      shell: bash
+      run: |
+        shopt -s extglob
+        rm -rf -v !("index.html"|"release"|"dev"|"CNAME"|".nojekyll")
+        ls -R
+
     - name: "Commit new changes (if required)"
       if: env.ACCEPTED_FORMAT == 'true'
       shell: bash

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -1,3 +1,5 @@
+Ansys
+ansys
 dev
 GitHub
 pytest


### PR DESCRIPTION
The following pull-request allows to clean the gh-pages branch. This was originally done by using the `clean` parameter in the old `gh-pages-deploy` action.

However, as a consequence of migrating to the `dev/` and `release/` structure, this needs to be performed trough and additional step inside development and stable doc deploy workflows.