### PR TITLE
Adding skip artifact download

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
     type: string
   use-downloaded-artifact:
-    description: "Skip downloading the artifact."
+    description: "Skip downloading the artifact. Uses the file <doc-artifact-name> at the working directory."
     required: false
     type: bool
     default: false

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -15,6 +15,11 @@ inputs:
     description: "Required token for documentation deployment."
     required: true
     type: string
+  use-downloaded-artifact:
+    description: "Skip downloading the artifact."
+    required: false
+    type: bool
+    default: false
 
 runs:
   using: "composite"
@@ -36,9 +41,15 @@ runs:
 
     - name: "Download the HTML documentation artifact"
       uses: actions/download-artifact@v3
+      if: ${{ github.event.inputs.use-downloaded-artifact == false }}
       with:
         name: ${{ inputs.doc-artifact-name }}
         path: dev
+
+    - name: "Move artifact to dev folder"
+      if: ${{ github.event.inputs.use-downloaded-artifact == true }}
+      run: |
+        mv ${{ inputs.doc-artifact-name }} dev
 
     - name: "Display structure of downloaded files"
       shell: bash

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: "Move artifact to dev folder"
       if: ${{ github.event.inputs.use-downloaded-artifact == true }}
       run: |
-        mv ${{ inputs.doc-artifact-name }} dev
+        unzip ${{ inputs.doc-artifact-name }}.zip ./dev/* -r
 
     - name: "Display structure of downloaded files"
       shell: bash


### PR DESCRIPTION
I'm working in a workflow which downloads the already build documentation from another workflow:

https://github.com/pyansys/pymapdl/pull/1707

Because I download the artifact from other workflow, the default ``actions/download-artifact`` does not work. Hence I would like to skip it in the current pyansys action.

Other option is for me to just copy this workflow but given the complexity of the latter steps, I would like to use this action as much as I can.