### PR TITLE
Allowing download artifacts from other workflows

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -20,6 +20,34 @@ inputs:
     required: false
     default: ""
     type: string
+  repo:
+    description: Repository name with owner (like actions/checkout)
+    required: false
+    default: ${{ github.repository }}
+  pr:
+    description: Pull request number
+    required: false
+  commit:
+    description: Commit hash
+    required: false
+  branch:
+    description: Branch name
+    required: false
+  event:
+    description: Event type
+    required: false
+  run_id:
+    description: Workflow run id
+    required: false
+  run_number:
+    description: Workflow run number
+    required: false
+  name:
+    description: Artifact name (download all artifacts if not specified)
+    required: false
+  dry_run:
+    description: Check the existence of artifact(s) without downloading
+    required: false
 
 runs:
   using: "composite"
@@ -46,15 +74,22 @@ runs:
         name: ${{ inputs.doc-artifact-name }}
         path: dev
 
-    - name: "Download the HTML documentation artifact from other workflow"
+    - name: "Download the HTML documentation artifact"
       if: ${{ inputs.workflow != "" }}
       uses: dawidd6/action-download-artifact@v2
       with:
+        branch: ${{ inputs.branch }}
+        commit: ${{ inputs.commit }}
+        dry_run: ${{ inputs.dry_run }}
+        event: ${{ inputs.event }}
         github_token: ${{ inputs.token }}
         name: ${{ inputs.doc-artifact-name }}
-        workflow: ${{ inputs.workflow }}
-        commit: ${{ github.event.pull.before }}
         path: dev
+        pr: ${{ inputs.pr }}
+        repo: ${{ inputs.repo }}
+        run_id: ${{ inputs.run_id }}
+        run_number: ${{ inputs.run_number }}
+        workflow: ${{ inputs.workflow }}
 
     - name: "Display structure of downloaded files"
       shell: bash

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -16,38 +16,47 @@ inputs:
     required: true
     type: string
   workflow:
-    description: "Workflow name from where the artifacts are downloaded. By default, the same running workflow"
+    description: 'Workflow name from where the artifacts are downloaded. By default, the same running workflow'
     required: false
     default: ""
     type: string
   repo:
-    description: Repository name with owner (like actions/checkout)
+    description: 'Repository name with owner (like actions/checkout)'
     required: false
     default: ${{ github.repository }}
+    type: string
   pr:
-    description: Pull request number
+    description: 'Pull request number'
     required: false
+    type: string
   commit:
-    description: Commit hash
+    description: 'Commit hash'
     required: false
+    type: string
   branch:
-    description: Branch name
+    description: 'Branch name'
     required: false
+    type: string
   event:
-    description: Event type
+    description: 'Event type'
     required: false
+    type: string
   run_id:
-    description: Workflow run id
+    description: 'Workflow run id'
     required: false
+    type: string
   run_number:
-    description: Workflow run number
+    description: 'Workflow run number'
     required: false
+    type: string
   name:
-    description: Artifact name (download all artifacts if not specified)
+    description: 'Artifact name (download all artifacts if not specified)'
     required: false
+    type: string
   dry_run:
-    description: Check the existence of artifact(s) without downloading
+    description: 'Check the existence of artifact(s) without downloading'
     required: false
+    type: string
 
 runs:
   using: "composite"

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -76,15 +76,7 @@ runs:
       shell: bash
       run: rm -rf dev/ && mkdir dev/
 
-    - name: "Download the HTML documentation artifact from the same workflow"
-      uses: actions/download-artifact@v3
-      if: ${{ inputs.workflow == "" }}
-      with:
-        name: ${{ inputs.doc-artifact-name }}
-        path: dev
-
     - name: "Download the HTML documentation artifact"
-      if: ${{ inputs.workflow != "" }}
       uses: dawidd6/action-download-artifact@v2
       with:
         branch: ${{ inputs.branch }}

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
     type: string
   workflow:
-    description: 'Workflow name from where the artifacts are downloaded. By default, the same running workflow'
+    description: 'Workflow name from where the artifacts are downloaded. By default, the same running workflow.'
     required: false
     default: ""
     type: string

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -15,6 +15,11 @@ inputs:
     description: "Required token for documentation deployment."
     required: true
     type: string
+  workflow:
+    description: "Workflow name from where the artifacts are downloaded. By default, the same running workflow"
+    required: false
+    default: ""
+    type: string
 
 runs:
   using: "composite"
@@ -34,10 +39,21 @@ runs:
       shell: bash
       run: rm -rf dev/ && mkdir dev/
 
-    - name: "Download the HTML documentation artifact"
+    - name: "Download the HTML documentation artifact from the same workflow"
       uses: actions/download-artifact@v3
+      if: ${{ inputs.workflow == "" }}
       with:
         name: ${{ inputs.doc-artifact-name }}
+        path: dev
+
+    - name: "Download the HTML documentation artifact from other workflow"
+      if: ${{ inputs.workflow != "" }}
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        github_token: ${{ inputs.token }}
+        name: ${{ inputs.doc-artifact-name }}
+        workflow: ${{ inputs.workflow }}
+        commit: ${{ github.event.pull.before }}
         path: dev
 
     - name: "Display structure of downloaded files"


### PR DESCRIPTION
As the title.

We should probably give many options for filtering the artifacts.

I'm using the default ``actions/download-artifact`` action unless one of the arguments is used, but I'm happy to drop it.