### PR TITLE
Making checkout optional

### DIFF
--- a/build-ci-wheels/action.yml
+++ b/build-ci-wheels/action.yml
@@ -33,7 +33,7 @@ inputs:
       required: false
       type: boolean
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/build-ci-wheels/action.yml
+++ b/build-ci-wheels/action.yml
@@ -32,6 +32,11 @@ inputs:
       default: false
       required: false
       type: boolean
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -39,6 +44,7 @@ runs:
 
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
     
     - name: "Set up Python ${{ inputs.python-version }}"
       uses: pyansys/actions/_setup-python@main

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: true
     type: boolean
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     default: true
     type: boolean
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -23,6 +28,7 @@ runs:
   
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
   
     - name: "Set up Python"
       uses: pyansys/actions/_setup-python@main

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -28,6 +28,11 @@ inputs:
     required: false
     default: ''
     type: string
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 
 runs:
@@ -36,6 +41,7 @@ runs:
 
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
   
     - name: "Set up Python ${{ inputs.python-version }}"
       uses: pyansys/actions/_setup-python@main

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: ''
     type: string
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/check-licenses/action.yml
+++ b/check-licenses/action.yml
@@ -22,6 +22,11 @@ inputs:
     required: false
     default: ''
     type: string
+  checkout:
+      description: 'Whether to checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"

--- a/check-licenses/action.yml
+++ b/check-licenses/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: "Install Git and clone project"
-      if: inputs.skip-install == 'false'
+      if: ${{ (inputs.skip-install == 'false') && (input.checkout == 'true') }}
       uses: actions/checkout@v3
 
     - name: "Set up Python"

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: true
     type: boolean
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -12,6 +12,11 @@ inputs:
     required: false
     default: true
     type: boolean
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -19,6 +24,7 @@ runs:
   
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
   
     - name: "Set up Python"
       uses: pyansys/actions/_setup-python@main

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -33,7 +33,7 @@ inputs:
       required: false
       type: boolean
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -32,6 +32,11 @@ inputs:
       default: false
       required: false
       type: boolean
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -39,6 +44,7 @@ runs:
   
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
 
     - name: "Check if X Virtual Frame Buffer is needed"
       shell: bash

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -44,7 +44,7 @@ runs:
   
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
-      if: ${{ input.checkout == 'true' }}
+      if: ${{ (inputs.skip-install == 'false') && (input.checkout == 'true') }}
 
     - name: "Check if X Virtual Frame Buffer is needed"
       shell: bash

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -58,7 +58,7 @@ inputs:
     required: false
     type: string
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -57,6 +57,11 @@ inputs:
     description: 'Check the existence of artifact(s) without downloading'
     required: false
     type: string
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -69,6 +74,7 @@ runs:
 
     - name: "Checkout project in the GitHub Pages branch"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
       with:
         ref: 'gh-pages'
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -30,6 +30,11 @@ inputs:
     default: '3'
     required: false
     type: string
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -37,6 +42,7 @@ runs:
 
     - name: "Checkout project in the GitHub Pages branch"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
       with:
         ref: 'gh-pages'
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: false
     type: string
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/doc-deploy-to-repo/action.yml
+++ b/doc-deploy-to-repo/action.yml
@@ -19,7 +19,8 @@ inputs:
     required: true
     type: string
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
+
       default: true
       required: false
       type: boolean

--- a/doc-deploy-to-repo/action.yml
+++ b/doc-deploy-to-repo/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: "Required application token for documentation deployment."
     required: true
     type: string
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -25,6 +30,7 @@ runs:
 
     - name: "Checkout project in the GitHub Pages branch"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
 
     - name: "Download the HTML documentation artifact"
       uses: actions/download-artifact@v3

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: true
     type: string
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -11,6 +11,11 @@ inputs:
     description: "Required token for Vale commenter."
     required: true
     type: string
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
 
 runs:
   using: "composite"
@@ -18,6 +23,7 @@ runs:
 
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
 
     - name: "Run Vale"
       uses: errata-ai/vale-action@reviewdog

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -32,7 +32,7 @@ inputs:
       required: false
       type: boolean
   checkout:
-      description: 'Whether checkout the repository or not'
+      description: 'Whether to checkout the repository or not'
       default: true
       required: false
       type: boolean

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -31,6 +31,12 @@ inputs:
       default: false
       required: false
       type: boolean
+  checkout:
+      description: 'Whether checkout the repository or not'
+      default: true
+      required: false
+      type: boolean
+
 
 runs:
   using: "composite"
@@ -38,6 +44,7 @@ runs:
   
     - name: "Install Git and clone project"
       uses: actions/checkout@v3
+      if: ${{ input.checkout == 'true' }}
   
     - name: "Set up Python"
       uses: pyansys/actions/_setup-python@main


### PR DESCRIPTION
Adding ``checkout`` optional argument to all the actions (almost all actually).

I also added an ``skip-install` condition to the ``doc-build`` checkout step. To be consistent with the ``check-license`` behavior.

Also, I'm not sure what is the recommend approach if:
``if: ${{ input.checkout == 'true' }}`` or ``if: input.checkout == 'true'``

Close #123 