### PR TITLE
FIX: missing input parameter

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -19,6 +19,11 @@ inputs:
     description: 'Workflow name from where the artifacts are downloaded. By default, the current running workflow.'
     required: false
     type: string
+  checkout:
+    description: 'If ``True``, the project is checkout in the ``gh-pages``. If ``False``, users are the ones in charge of performing the checkout step.'
+    required: false
+    default: true
+    type: string
 
 runs:
   using: "composite"
@@ -31,7 +36,7 @@ runs:
 
     - name: "Checkout project in the GitHub Pages branch"
       uses: actions/checkout@v3
-      if: ${{ inputs.checkout == 'true' }}
+      if: inputs.checkout == 'true'
       with:
         ref: 'gh-pages'
 

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     type: string
   checkout:
-    description: 'If ``True``, the project is checkout in the ``gh-pages``. If ``False``, users are the ones in charge of performing the checkout step.'
+    description: 'If ``True``, the project is checked out in the ``gh-pages`` branch. If ``False``, users are the ones in charge of performing the checkout step.'
     required: false
     default: true
     type: string


### PR DESCRIPTION
The `checkout` input parameter was missing in the `doc-deploy-dev` action. This pull-request fixes this bug.