### PR TITLE
FEAT: use ouch for artifact decompression

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -37,7 +37,8 @@ runs:
     - name: "Install system dependencies"
       shell: bash
       run: |
-        sudo apt-get install curl unzip
+        sudo apt-get install cargo curl
+        cargo install ouch && ouch --version
 
     - name: "Checkout project in the GitHub Pages branch"
       uses: actions/checkout@v3
@@ -63,8 +64,9 @@ runs:
       if: inputs.decompress_artifact == 'true'
       working-directory: dev
       run: |
-        unzip ${{ inputs.doc-artifact-name }}.zip
-        rm ${{ inputs.doc-artifact-name }}.zip
+        compressed_artifact=$(ls .)
+        ouch decompress $compressed_artifact
+        rm $compressed_artifact
 
     - name: "Display structure of downloaded files"
       shell: bash

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -103,9 +103,12 @@ runs:
       working-directory: release/${{ env.VERSION }}
       if: inputs.decompress_artifact == 'true'
       run: |
-        sudo apt-get install unzip
-        unzip ${{ inputs.doc-artifact-name }}.zip
-        rm ${{ inputs.doc-artifact-name }}.zip
+        sudo apt-get install cargo
+        cargo install ouch && ouch --version
+
+        compressed_artifact=$(ls .)
+        ouch decompress $compressed_artifact
+        rm $compressed_artifact
   
     - name: "Set up Python ${{ inputs.python-version }}"
       if: env.ACCEPTED_FORMAT == 'true'


### PR DESCRIPTION
Fixes #148 by using [ouch](https://github.com/ouch-org/ouch) for using the right decompressing tool. No additional dependencies are required.