### PR TITLE
FIX: download artifacts from desired workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: black
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     args:

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -23,6 +23,7 @@ inputs:
   workflow:
     description: 'Workflow name from where the artifacts are downloaded. By default, the current running workflow.'
     required: false
+    default: ''
     type: string
   checkout:
     description: 'If ``True``, the project is checked out in the ``gh-pages`` branch. If ``False``, users are the ones in charge of performing the checkout step.'
@@ -51,13 +52,22 @@ runs:
       run: |
         rm -rf dev/ && mkdir dev/
 
-    - name: "Download the HTML documentation artifact"
+    - name: "Download the HTML documentation artifact from desired workflow"
       uses: dawidd6/action-download-artifact@v2
+      if: inputs.workflow != ''
       with:
         github_token: ${{ inputs.token }}
         name: ${{ inputs.doc-artifact-name }}
         path: dev
         workflow: ${{ inputs.workflow }}
+
+    - name: "Download the HTML documentation artifact from current workflow"
+      uses: dawidd6/action-download-artifact@v2
+      if: inputs.workflow != ''
+      with:
+        github_token: ${{ inputs.token }}
+        name: ${{ inputs.doc-artifact-name }}
+        path: dev
 
     - name: "Decompress artifact content if required"
       shell: bash

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -25,6 +25,11 @@ inputs:
     required: false
     default: ''
     type: string
+  workflow-conclusion:
+    description: 'Workflow conclusion (options: "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required") or status (options: "completed", "in_progress", "queued") to search for. Use the empty string ("") to ignore status or conclusion in the search.'
+    required: false
+    default: ''
+    type: string
   checkout:
     description: 'If ``True``, the project is checked out in the ``gh-pages`` branch. If ``False``, users are the ones in charge of performing the checkout step.'
     required: false
@@ -60,6 +65,7 @@ runs:
         name: ${{ inputs.doc-artifact-name }}
         path: dev
         workflow: ${{ inputs.workflow }}
+        workflow_conclusion: ${{ inputs.workflow-conclusion }}
 
     - name: "Download the HTML documentation artifact from current workflow"
       uses: dawidd6/action-download-artifact@v2

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: "Download the HTML documentation artifact from current workflow"
       uses: dawidd6/action-download-artifact@v2
-      if: inputs.workflow != ''
+      if: inputs.workflow == ''
       with:
         github_token: ${{ inputs.token }}
         name: ${{ inputs.doc-artifact-name }}


### PR DESCRIPTION
Fixes the recent issues in:

* Pyfluent visualization: https://github.com/pyansys/pyfluent-visualization/actions/runs/3992912227/jobs/6849174814
* PyAEDT: https://github.com/pyansys/pyaedt/actions/runs/3992907653
* Other internal repositories that just upgraded to pyansys/actions@v3.

I feel the conflict is being caused because the value for the `workflow` is not behaving as expected. Hence, I went with this "duplicated" logic. This is the original logic from pyansys/actions@v2.0.7, which has been proven to work.

I do not like to keep patching stuff in here but I did not see other option for the moment. Once we agree on https://github.com/pyansys/actions/discussions/141, everything will be unified for @v4.