### PR TITLE
Setting a compatible value for ``workflow_conclusion`` argument

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -29,6 +29,11 @@ inputs:
     required: false
     default: true
     type: string
+  workflow_conclusion:
+    description: 'Workflow conclusion (options: "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required") or status (options: "completed", "in_progress", "queued") to search for. Use the empty string ("") to ignore status or conclusion in the search.'
+    required: false
+    default: ''
+    type: string
 
 runs:
   using: "composite"
@@ -58,6 +63,7 @@ runs:
         name: ${{ inputs.doc-artifact-name }}
         path: dev
         workflow: ${{ inputs.workflow }}
+        workflow_conclusion: ${{ inputs.workflow_conclusion }}
 
     - name: "Decompress artifact content if required"
       shell: bash


### PR DESCRIPTION
See https://github.com/pyansys/actions/pull/150#issuecomment-1406795131

Replace #150 

I'm always into exposing things (APIs!! 😄), but this PR could work too just doing:

```yml
    - name: "Download the HTML documentation artifact"
      uses: dawidd6/action-download-artifact@v2
      with:
        github_token: ${{ inputs.token }}
        name: ${{ inputs.doc-artifact-name }}
        path: dev
        workflow: ${{ inputs.workflow }}
        workflow_conclusion: ""
 ```
 
 But I think this is a good oportunity to expose... howeeeeever... I cannot really see in which situations this argument might be useful.