### PR TITLE
FIX: allow the usage of actions/download-artifact again

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -68,10 +68,9 @@ runs:
         workflow_conclusion: ${{ inputs.workflow-conclusion }}
 
     - name: "Download the HTML documentation artifact from current workflow"
-      uses: dawidd6/action-download-artifact@v2
+      uses: actions/download-artifact@v3
       if: inputs.workflow == ''
       with:
-        github_token: ${{ inputs.token }}
         name: ${{ inputs.doc-artifact-name }}
         path: dev
 


### PR DESCRIPTION
Continuation of #150. This introduces the actions/download-artifact, which is the one that originally got implemented. This way both dawidd6/download-artifact and actions/download-artifact coexist in v3.