### PR TITLE
Wheels should be uploaded - error in naming

### DIFF
--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -61,8 +61,8 @@ runs:
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          ${{ inputs.library-name }}/*.whl
-          ${{ inputs.library-name }}/*.tar.gz
+          ${{ inputs.library-name }}-artifacts/*.whl
+          ${{ inputs.library-name }}-artifacts/*.tar.gz
           documentation-html.zip
           documentation-pdf.zip
           other-artifacts/**/*-wheelhouse-*.zip


### PR DESCRIPTION
Seen in https://github.com/pyansys/pygeometry/actions/runs/4132811802/jobs/7142191585#step:3:1437

When attempting to perform GitHub release, the wheels are not found because of the artifact naming convention. This has to be fixed and patched released