### PR TITLE
CI: improve pipelines

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -19,80 +19,70 @@ concurrency:
 
 jobs:
 
-  label-syncer:
-    name: Label syncer
+  labeler:
+    name: "Label syncer"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: micnncim/action-label-syncer@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  labeler:
-    name: Set labels
-    needs: [label-syncer]
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
+      - name: Label based on changed files
+        uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: ''
 
-    - name: Label based on changed files
-      uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: ''
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: |
+          startsWith(github.event.pull_request.head.ref, 'doc') ||
+          startsWith(github.event.pull_request.head.ref, 'docs')
+        with:
+          labels: documentation
 
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: |
-        startsWith(github.event.pull_request.head.ref, 'doc') ||
-        startsWith(github.event.pull_request.head.ref, 'docs')
-      with:
-        labels: documentation
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: |
+          startsWith(github.event.pull_request.head.ref, 'maint') ||
+          startsWith(github.event.pull_request.head.ref, 'no-ci') ||
+          startsWith(github.event.pull_request.head.ref, 'ci')
+        with:
+          labels: maintenance
 
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: |
-        startsWith(github.event.pull_request.head.ref, 'maint') ||
-        startsWith(github.event.pull_request.head.ref, 'no-ci') ||
-        startsWith(github.event.pull_request.head.ref, 'ci')
-      with:
-        labels: maintenance
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: startsWith(github.event.pull_request.head.ref, 'feat')
+        with:
+          labels: |
+            enhancement
 
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: startsWith(github.event.pull_request.head.ref, 'feat')
-      with:
-        labels: |
-          enhancement
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: |
+          startsWith(github.event.pull_request.head.ref, 'fix') ||
+          startsWith(github.event.pull_request.head.ref, 'patch')
+        with:
+          labels: bug
 
-    - uses: actions-ecosystem/action-add-labels@v1
-      if: |
-        startsWith(github.event.pull_request.head.ref, 'fix') ||
-        startsWith(github.event.pull_request.head.ref, 'patch')
-      with:
-        labels: bug
-
-  commenter:
-    runs-on: ubuntu-latest
-    needs: [label-syncer, labeler]
-    steps:
-    - name: Suggest to add labels
-      uses: peter-evans/create-or-update-comment@v2
-      if: toJSON(github.event.pull_request.labels.*.name) == '{}'
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          Please add one of the following labels to add this contribution to the Release Notes :point_down:
-          - [bug](https://github.com/pyansys/actions/pulls?q=label%3Abug+)
-          - [documentation](https://github.com/pyansys/actions/pulls?q=label%3Adocumentation+)
-          - [enhancement](https://github.com/pyansys/actions/pulls?q=label%3Aenhancement+)
-          - [good first issue](https://github.com/pyansys/actions/pulls?q=label%3Agood+first+issue)
-          - [maintenance](https://github.com/pyansys/actions/pulls?q=label%3Amaintenance+)
-          - [release](https://github.com/pyansys/actions/pulls?q=label%3Arelease+)
+      - name: Suggest to add labels
+        uses: peter-evans/create-or-update-comment@v2
+        if: toJSON(github.event.pull_request.labels.*.name) == '{}'
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Please add one of the following labels to add this contribution to the Release Notes :point_down:
+            - [bug](https://github.com/pyansys/actions/pulls?q=label%3Abug+)
+            - [documentation](https://github.com/pyansys/actions/pulls?q=label%3Adocumentation+)
+            - [enhancement](https://github.com/pyansys/actions/pulls?q=label%3Aenhancement+)
+            - [good first issue](https://github.com/pyansys/actions/pulls?q=label%3Agood+first+issue)
+            - [maintenance](https://github.com/pyansys/actions/pulls?q=label%3Amaintenance+)
+            - [release](https://github.com/pyansys/actions/pulls?q=label%3Arelease+)
 
   code-style:
     name: "Code style"
     runs-on: ubuntu-latest
-    needs: commenter
+    needs: labeler
     steps:
       - name: "Run code style checks"
         uses: pyansys/actions/code-style@main
@@ -103,7 +93,7 @@ jobs:
   doc-style:
     name: "Doc style"
     runs-on: ubuntu-latest
-    needs: commenter
+    needs: labeler
     steps:
       - name: "Run documentation style checks"
         uses: pyansys/actions/doc-style@main
@@ -111,7 +101,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-build:
-    name: "Building documentation"
+    name: "Doc build"
     runs-on: ubuntu-latest
     needs: doc-style
     steps:
@@ -122,33 +112,8 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           use-python-cache: false
 
-  doc-deploy-dev:
-    name: "Deploy developers documentation"
-    runs-on: ubuntu-latest
-    needs: doc-build
-    steps:
-      - name: "Deploy developers documentation"
-        if: github.event_name == 'push'
-        uses: pyansys/actions/doc-deploy-dev@main
-        with:
-            cname: ${{ env.DOCUMENTATION_CNAME }}
-            token: ${{ secrets.GITHUB_TOKEN }}
-
-  doc-deploy-stable:
-    name: "Deploy stable documentation"
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: doc-deploy-dev
-    steps:
-      - name: "Deploy stable documentation"
-        uses: pyansys/actions/doc-deploy-stable@main
-        with:
-            cname: ${{ env.DOCUMENTATION_CNAME }}
-            token: ${{ secrets.GITHUB_TOKEN }}
-            python-version: ${{ env.MAIN_PYTHON_VERSION }}
-
-  tests-build:
-    name: "Test library build"
+  tests:
+    name: "Tests"
     runs-on: ubuntu-latest
     needs: code-style
     steps:
@@ -183,24 +148,29 @@ jobs:
         path: ~/${{ env.test-library-name }}/dist/
         retention-days: 7
 
-  tests-release-pypi-test:
-    name: "Test release to Test PyPI"
-    runs-on: ubuntu-latest
-    needs: tests-build
-    steps:
     - name: "Release to the test PyPI repository"
       uses: pyansys/actions/release-pypi-test@main
       with:
         library-name: ${{ env.test-library-name }}
         twine-username: "__token__"
         twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
-        python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
-  release-gitub:
+  doc-deploy-dev:
+    name: "Deploy developers documentation"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
+    needs: [doc-build, tests]
+    steps:
+      - uses: pyansys/actions/doc-deploy-dev@main
+        with:
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
     name: "Release to GitHub"
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [doc-deploy-stable, tests-release-pypi-test]
+    needs: [doc-build, tests]
     steps:
 
     - name: "Download HTML documentation"
@@ -237,3 +207,14 @@ jobs:
         files: |
           documentation-html.zip
           documentation-pdf.zip
+
+  doc-deploy-stable:
+    name: "Deploy stable documentation"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: release
+    steps:
+      - uses: pyansys/actions/doc-deploy-stable@main
+        with:
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Improves the current pipelines to guarantee that the development documentation gets published only after building docs and passing all tests. Also, stable documentation is only published after a successfully release.

![pipelines](https://user-images.githubusercontent.com/28702884/220328377-46fa065b-49ee-4d61-8985-2dd951ee0283.png)
