### PR TITLE
MAINT: update doc dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "pip"
     directory: "/requirements"
     schedule:
       interval: "daily"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,7 +45,6 @@ html_theme_options = {
         "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
     },
-    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
 }
 
 # Specify Sphinx extensions to use

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,4 +1,4 @@
-ansys-sphinx-theme==0.7.3
+ansys-sphinx-theme==0.9.0
 pyyaml==6.0.0
 Sphinx==5.3.0
 sphinx-copybutton==0.5.1


### PR DESCRIPTION
This pull-request updates the documentation dependencies. Also, I noticed that dependabot was pointing to the wrong ecosystem for the Python requirements. Fixing this too.