### PR TITLE
FEAT: add logging action

### DIFF
--- a/_logging/action.yml
+++ b/_logging/action.yml
@@ -1,0 +1,47 @@
+name: >
+  Utils logging action
+
+description: >
+  This action is used to generate logging messages during the execution of other
+  actions. It supports three logging levels including ``ERROR``, ``WARNING``,
+  and ``INFO``. ANSI colors are used to report the different levels. This allows
+  to quickly identify those in the GitHub actions logs.
+
+inputs:
+   
+  # Required inputs
+
+  level:
+    description: >
+      Logging level of the message. Supported levels are ``ERROR``, ``WARNING``
+      and ``INFO``.
+    required: true
+    type: string
+
+  message:
+    description: >
+      The message to save in the logging report.
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+  
+    - name: "Report error message"
+      shell: bash
+      if: ${{ inputs.level == 'ERROR' }}
+      run: |
+        echo -e "\033[1;91m[ERROR]: ${{ inputs.message }}\033[0m"
+
+    - name: "Report warning message"
+      shell: bash
+      if: ${{ inputs.level == 'WARNING' }}
+      run: |
+        echo -e "\033[1;93m[WARNING]: ${{ inputs.message }}\033[0m"
+
+    - name: "Report info message"
+      shell: bash
+      if: ${{ inputs.level == 'INFO' }}
+      run: |
+        echo -e "\033[1;92m[INFO]: ${{ inputs.message }}\033[0m"

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -42,8 +42,14 @@ runs:
   using: "composite"
   steps:
 
-    # Checkout the repository branch for deploying the documentation. If this
-    # step fails, then it means that the provided token is not valid.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Checkout the repository branch for deploying the documentation. If
+          this step fails, then it means that the provided token is not valid.
 
     - name: "Get the name of the repository"
       shell: bash
@@ -61,10 +67,16 @@ runs:
         ref: ${{ inputs.branch }}
         token: ${{ inputs.token }}
 
-    # Download the documentation artifact from the current workflow. If the
-    # artifact contains a compressed file, decompress it. Display the structure
-    # of the 'version/dev' directory at the end of the process to verify the
-    # layout of the folder is the right one.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Download the documentation artifact from the current workflow. If the
+          artifact contains a compressed file, decompress it. Display the
+          structure of the 'version/dev' directory at the end of the process to
+          verify the layout of the folder is the right one.
 
     - name: "Clean destination folder"
       shell: bash
@@ -90,10 +102,16 @@ runs:
       run: |
         ls -R version/dev
 
-    # Create the 'versions.json' file if it does not exist. Note that this step
-    # is not required in the 'doc-deploy-stable' action. The reason is that
-    # stable releases are born after a development version exists. This forces
-    # users to use this action before using the stable deploy one.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Create the 'versions.json' file if it does not exist. Note that this
+          step is not required in the 'doc-deploy-stable' action. The reason is
+          that stable releases are born after a development version exists. This
+          forces users to use this action before using the stable deploy one.
 
     - name: "Create the 'versions.json' file if not present"
       shell: bash
@@ -107,9 +125,16 @@ runs:
         fi
         cat versions.json
 
-    # Generate an 'index.html' for redirection to the latest stable version of
-    # the documentation. If no stable version has been release, a redirection
-    # to the development documentation is generated.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Generate an 'index.html' for redirection to the latest stable version
+          of the documentation. If no stable version has been release, a
+          redirection to the development documentation is generated.
+
 
     - name: "Generate the redirection URL"
       shell: bash
@@ -137,18 +162,30 @@ runs:
       run: |
           cat index.html
 
-    # Create the '.nojekyll' and 'CNAME' file with the desired values
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Create the '.nojekyll' and 'CNAME' file with the desired values
 
     - name: "Create '.nojekyll' and 'CNAME' files"
       shell: bash
       run: |
           touch .nojekyll CNAME
           echo "${{ inputs.cname }}" > CNAME
-      
-    # For deploying the documentation, a GitHub token or a deployment token is
-    # required. The GitHub token is used when deploying to the current
-    # repository while the deployment token is used to deploy to an external
-    # repository.
+
+     # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          For deploying the documentation, a GitHub token or a deployment token
+          is required. The GitHub token is used when deploying to the current
+          repository while the deployment token is used to deploy to an external
+          repository.
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
       if: inputs.repository == 'current'

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -45,10 +45,16 @@ runs:
   using: "composite"
   steps:
 
-    # Collect the version number from the tag or the branch name according to
-    # the reference type. Tags names are expected to follow 'v<MAJOR>.<MINOR>'
-    # or 'v<MAJOR>.<MINOR>.<PATCH>'. Braches must follow
-    # 'release/<MAJOR>.<MINOR>'.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Collect the version number from the tag or the branch name according
+          to the reference type. Tags names are expected to follow
+          'v<MAJOR>.<MINOR>' or 'v<MAJOR>.<MINOR>.<PATCH>'. Braches must follow
+          'release/<MAJOR>.<MINOR>'.
 
     - name: "Collect version number from the tag"
       shell: bash
@@ -60,8 +66,7 @@ runs:
         if [[ $version =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
           echo "VERSION_RAW=$(echo $version)" >> $GITHUB_ENV
         else
-          echo "[PYANSYS ACTIONS ERROR]"
-          echo "Tag names must follow 'v<MAJOR>.<MINOR>.<PATCH> name convention.'"
+          echo -e "\033[1;91m[ERROR]: Tag names must follow 'v<MAJOR>.<MINOR>.<PATCH> name convention.'\033[0m"
           exit 1
         fi
 
@@ -75,8 +80,7 @@ runs:
         if [[ $version =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
           echo "VERSION_RAW=$(echo $version)" >> $GITHUB_ENV
         else
-          echo "[PYANSYS ACTIONS ERROR]"
-          echo "Branch names must follow 'release/<MAJOR>.<MINOR>' name convention."
+          echo -e "\033[1;91m[ERROR]: Branch names must follow 'release/<MAJOR>.<MINOR>' name convention.\033[0m"
           exit 1
         fi
 
@@ -87,8 +91,14 @@ runs:
           minor=$(echo ${{ env.VERSION_RAW }} | cut -d . -f 2)
           echo "VERSION=$major.$minor" >> $GITHUB_ENV
 
-    # Checkout the repository branch for deploying the documentation. If this
-    # step fails, then it means that the provided token is not valid.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Checkout the repository branch for deploying the documentation. If this
+          step fails, then it means that the provided token is not valid.
 
     - name: "Get the name of the repository"
       shell: bash
@@ -106,10 +116,16 @@ runs:
         ref: ${{ inputs.branch }}
         token: ${{ inputs.token }}
 
-    # Download the stable documentation artifact in a folder that has the same
-    # name as the version number. Decompress artifact if required. Finally,
-    # display the structure of the directory to verify that it has the right
-    # layout.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Download the stable documentation artifact in a folder that has the same
+          name as the version number. Decompress artifact if required. Finally,
+          display the structure of the directory to verify that it has the right
+          layout.
 
     - name: "Clean version content"
       shell: bash
@@ -140,9 +156,15 @@ runs:
       run: |
         ls -R version/${{ env.VERSION }}
 
-    # Collect all stable releases (X.Y). Crop until matching the desired number
-    # to be displayed in the switcher. Generate the 'versions.json' file including
-    # development and latest stable links.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Collect all stable releases (X.Y). Crop until matching the desired
+          number to be displayed in the switcher. Generate the 'versions.json'
+          file including development and latest stable links.
 
     - name: "Install 'sponge' and 'jq' for manipulating JSON files"
       shell: bash
@@ -193,8 +215,14 @@ runs:
       run: |
         rm -rf version/stable && cp -r version/${{ env.LATEST_STABLE_VERSION }} version/stable
 
-    # Generate the content for the announcement file. Place a copy of this file
-    # in each one of outdated stable versions. 
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Generate the content for the announcement file. Place a copy of this
+          file in each one of outdated stable versions. 
 
     - name: "Generate the template content for the 'announcement.html' file"
       shell: bash
@@ -229,9 +257,15 @@ runs:
       run: |
         rm -rf announcement.html
 
-    # Generate the redirection link. Since this is the stable documentation
-    # deployment action, there is always a 'version/stable' folder. Hence,
-    # redirection link always points to this folder.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Generate the redirection link. Since this is the stable documentation
+          deployment action, there is always a 'version/stable' folder. Hence,
+          redirection link always points to this folder.
 
     - name: "Generate the redirection URL"
       shell: bash
@@ -252,7 +286,13 @@ runs:
       run: |
           cat index.html
 
-    # Create the '.nojekyll' and 'CNAME' file with the desired values
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Create the '.nojekyll' and 'CNAME' file with the desired values.
 
     - name: "Create '.nojekyll' and 'CNAME' files"
       shell: bash
@@ -260,10 +300,16 @@ runs:
           touch .nojekyll CNAME
           echo "${{ inputs.cname }}" > CNAME
 
-    # For deploying the documentation, a GitHub token or a deployment token is
-    # required. The GitHub token is used when deploying to the current
-    # repository while the deployment token is used to deploy to an external
-    # repository.
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          For deploying the documentation, a GitHub token or a deployment token
+          is required. The GitHub token is used when deploying to the current
+          repository while the deployment token is used to deploy to an external
+          repository.
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
       if: inputs.repository == 'current'


### PR DESCRIPTION
Related with #142. Includes a new action named `_logging` that contains three different levels: error (red), warning (yellow) and info (green).

As an example, consider this actions log: https://github.com/pyansys/test-multiversion/actions/runs/4245246509/jobs/7380502179

![Screenshot_20230222_182141](https://user-images.githubusercontent.com/28702884/220708834-8885646b-741b-4cfa-bccb-32e395b3ea3b.png)

Update. Now the color code is echoed is included directly in the message to avoid the logs showing any variables.