### PR TITLE
FEAT: allow additional artifacts and dry-runs for critical workflows

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -43,6 +43,15 @@ inputs:
     required: true
     type: string
 
+  dry-run:
+    description: >
+      Whether to run or not this action in testing mode. Testing mode executes
+      all the action steps except the releasing artifacts one. This allows
+      developers to verify the health of the action once integrated in their
+      CI/CD pipelines without actually publishing artifacts.
+    required: true
+    type: string
+
 runs:
   using: "composite"
   steps:
@@ -70,6 +79,7 @@ runs:
 
     - name: "Upload artifacts to private PyPi"
       shell: bash
+      if: ${{ inputs.dry-run != "false" }}
       run: |
         python -m twine upload --verbose --skip-existing ${{ inputs.library-name }}-artifacts/*.whl
         python -m twine upload --verbose --skip-existing ${{ inputs.library-name }}-artifacts/*.tar.gz

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -100,11 +100,28 @@ runs:
           Create a dist/wheelhouse directory and move all wheelhouse artifacts
           inside this folder.
 
-    - name: "Move documentation artifacts to dist/documentation directory"
+    - name: "Move wheelhouse artifacts to dist/wheelhouse directory"
       shell: bash
       run: |
         mkdir -p dist/wheelhouse
         mv /tmp/artifacts/**/*-wheelhouse-*.zip dist/wheelhouse/
+
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Create a dist/extra directory and move all the desired additional
+          artifacts inside this directory.
+
+    - name: "Move additional artifacts to dist/wheelhouse directory"
+      shell: bash
+      run: |
+        mkdir -p dist/extra
+        for artifact in (${${{ inputs.additional-artifacts }}}); do
+          mv /tmp/artifacts/$artifact dist/extra/$artifact
+        done
 
     # ------------------------------------------------------------------------
 

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -28,68 +28,111 @@ inputs:
     default: ''
     type: string
 
+  dry-run:
+    description: >
+      Whether to run or not this action in testing mode. Testing mode executes
+      all the action steps except the releasing artifacts one. This allows
+      developers to verify the health of the action once integrated in their
+      CI/CD pipelines without actually publishing artifacts. Default value is
+      ``false``.
+    required: false
+    default: false
+    type: string
+
+
 runs:
   using: "composite"
   steps:
+
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Download all artifacts that got generated in the CI/CD. Create a
+          directory containing the final artifacts to be published in GitHub.
+
+    - name: "Download all artifacts that got generated in the CI/CD"
+      uses: actions/download-artifact@v3
+      with:
+        path: /tmp/artifacts
+
+    - name: "Generate a distribution folder that will contain the desired artifacts"
+      shell: bash
+      run: mkdir -p dist
   
-    - name: "Download the ${{ inputs.library-name }} artifacts from build-library step"
-      uses: actions/download-artifact@v3
-      with:
-        name: ${{ inputs.library-name }}-artifacts
-        path: ${{ inputs.library-name }}-artifacts
+    # ------------------------------------------------------------------------
 
-    - name: "Download {{ inputs.library-name }} HTML documentation"
-      uses: actions/download-artifact@v3
+    - uses: pyansys/actions/_logging@main
       with:
-        name: documentation-html
-        path: documentation-html
+        level: "INFO"
+        message: >
+          Create a dist/documentation directory and move the documentation-html
+          artifact and the documentation-pdf artifact inside this folder.
+          Finally, compress both artifacts.
 
-    - name: "Zip HTML documentation"
+    - name: "Moving documentation artifacts to dist/documentation directory"
+      shell: bash
+      run: |
+        mkdir -p dist/documentation
+        mv /tmp/artifacts/documentation-html dist/documentation/documentation-html
+        mv /tmp/artifacts/documentation-pdf dist/documentation/documentation-pdf
+
+    - name: "Compressing HTML documentation"
       uses: vimtor/action-zip@v1.1
       with:
-        files: documentation-html
-        dest: documentation-html.zip
+        files: dist/documentation/documentation-html
+        dest: dist/documentation/documentation-html.zip
 
-    - name: "Download {{ inputs.library-name }} PDF documentation"
-      uses: actions/download-artifact@v3
-      with:
-        name: documentation-pdf
-        path: documentation-pdf
-
-    - name: "Zip PDF documentation"
+    - name: "Compressing PDF documentation"
       uses: vimtor/action-zip@v1.1
       with:
         files: documentation-pdf
         dest: documentation-pdf.zip
 
-    - name: "Download all artifacts that got generated in the CI/CD"
-      uses: actions/download-artifact@v3
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
       with:
-        path: all-artifacts
+        level: "INFO"
+        message: >
+          Create a dist/wheelhouse directory and move all wheelhouse artifacts
+          inside this folder.
 
-    - name: "Isolate wheelhouse artifacts"
+    - name: "Move documentation artifacts to dist/documentation directory"
       shell: bash
       run: |
-        mkdir -p wheelhouse
-        mv all-artifacts/**/*-wheelhouse-*.zip wheelhouse/
+        mkdir -p dist/wheelhouse
+        mv /tmp/artifacts/**/*-wheelhouse-*.zip dist/wheelhouse/
 
-    - name: "Remove undesired artifacts"
-      shell: bash
-      run: |
-        mkdir 
-        rm -rf other-artifacts/documentation-html
-        rm -rf other-artifacts/documentation-pdf
-        rm -rf other-artifacts/${{ inputs.library-name }}-artifacts
+    # ------------------------------------------------------------------------
 
-    - name: "Display the structure of downloaded files"
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Display and 
+
+    - name: "Display the structure of the artifacts folder"
       shell: bash
-      run: ls -R
+      run: ls -R dist/
 
     - name: "Release to GitHub"
       uses: softprops/action-gh-release@v1
+      if: ${{ inputs.dry-run != "false" }}
       with:
         files: |
-          ${{ inputs.library-name }}-artifacts/*.whl
-          ${{ inputs.library-name }}-artifacts/*.tar.gz
-          documentation-html.zip
-          documentation-pdf.zip
+          # Include wheel and source distribution artifacts
+          dist/${{ inputs.library-name }}-artifacts/*.whl
+          dist/${{ inputs.library-name }}-artifacts/*.tar.gz
+
+          # Include wheelhouse artifacts
+          dist/wheelhouse/**/*-wheelhouse-*.zip
+
+          # Include HTML and PDF documentation artifacts
+          dist/documentation/documentation-html.zip
+          dist/documentation/documentation-pdf.zip
+
+          # Include additional artifacts
+          dist/extra/**/*

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -18,6 +18,16 @@ inputs:
     required: true
     type: string
 
+  # Optional inputs
+
+  additional-artifacts:
+    description: >
+        String containing a list of additional artifacts to be included in the
+        GitHub release.
+    required: false
+    default: ''
+    type: string
+
 runs:
   using: "composite"
   steps:
@@ -52,14 +62,21 @@ runs:
         files: documentation-pdf
         dest: documentation-pdf.zip
 
-    - name: "Download other artifacts (wheelhouse, cibuildwheel...)"
+    - name: "Download all artifacts that got generated in the CI/CD"
       uses: actions/download-artifact@v3
       with:
-        path: other-artifacts
+        path: all-artifacts
 
-    - name: "Remove duplicated artifacts"
+    - name: "Isolate wheelhouse artifacts"
       shell: bash
       run: |
+        mkdir -p wheelhouse
+        mv all-artifacts/**/*-wheelhouse-*.zip wheelhouse/
+
+    - name: "Remove undesired artifacts"
+      shell: bash
+      run: |
+        mkdir 
         rm -rf other-artifacts/documentation-html
         rm -rf other-artifacts/documentation-pdf
         rm -rf other-artifacts/${{ inputs.library-name }}-artifacts
@@ -76,4 +93,3 @@ runs:
           ${{ inputs.library-name }}-artifacts/*.tar.gz
           documentation-html.zip
           documentation-pdf.zip
-          other-artifacts/**/*-wheelhouse-*.zip

--- a/release-pypi-private/action.yml
+++ b/release-pypi-private/action.yml
@@ -32,6 +32,17 @@ inputs:
 
   # Optional inputs
 
+  dry-run:
+    description: >
+      Whether to run or not this action in testing mode. Testing mode executes
+      all the action steps except the releasing artifacts one. This allows
+      developers to verify the health of the action once integrated in their
+      CI/CD pipelines without actually publishing artifacts. Default value is
+      ``false``.
+    required: false
+    default: false
+    type: string
+
   python-version:
     description: >
       Python version for installing and using `twine
@@ -52,3 +63,4 @@ runs:
         twine-username: ${{ inputs.twine-username }}
         twine-token: ${{ inputs.twine-token }}
         python-version: ${{ inputs.python-version }}
+        dry-run: ${{ inputs.dry-run }}

--- a/release-pypi-public/action.yml
+++ b/release-pypi-public/action.yml
@@ -4,7 +4,7 @@ name: >
 description: >
   Release library artifacts to the PyPI public index. Use the ``PYPI_TOKEN`` as
   the token. Artifacts get downloaded from the CI/CD pipeline and are assumed to be
-  named ``<library-name>-artifacts``. This file is expected to contain a wheel
+  named ``<library-name>-artifacts``. This file is expected to contain a wheel file
   and a source distribution file for the desired library.
 
 inputs:
@@ -31,6 +31,17 @@ inputs:
 
   # Optional inputs
 
+  dry-run:
+    description: >
+      Whether to run or not this action in testing mode. Testing mode executes
+      all the action steps except the releasing artifacts one. This allows
+      developers to verify the health of the action once integrated in their
+      CI/CD pipelines without actually publishing artifacts. Default value is
+      ``false``.
+    required: false
+    default: false
+    type: string
+
   python-version:
     description: >
       Python version for installing and using `twine
@@ -51,3 +62,4 @@ runs:
         twine-username: ${{ inputs.twine-username }}
         twine-token: ${{ inputs.twine-token }}
         python-version: ${{ inputs.python-version }}
+        dry-run: ${{ inputs.dry-run }}

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -1,24 +1,56 @@
-name: "Release to test PyPI index."
-description: "Release library artifacts to test PyPI index."
+name: >
+  Release to Test PyPI public index
+
+description: >
+  Release library artifacts to the Test PyPI public index. Use the
+  ``PYANSYS_PYPI_TEST_PAT`` as the token. Artifacts get downloaded from the
+  CI/CD pipeline and are assumed to be named ``<library-name>-artifacts``. This
+  file is expected to contain a wheel file and a source distribution file for
+  the desired library.
 
 inputs:
+
+  # Required inputs
+
   library-name:
-    description: 'Name of the Python library.'
+    description: >
+      Name of the Python library to be published.
     required: true
     type: string
+
   twine-username:
-    description: 'Desired twine user name.'
+    description: >
+      User name used when uploading to the public Test PyPI index.
     required: true
     type: string
+
   twine-token:
-    description: 'Password to be used when uploading to test PyPI.'
+    description: >
+      Password used when uploading to the public Test PyPI index.
     required: true
     type: string
+
+  # Optional inputs
+
+  dry-run:
+    description: >
+      Whether to run or not this action in testing mode. Testing mode executes
+      all the action steps except the releasing artifacts one. This allows
+      developers to verify the health of the action once integrated in their
+      CI/CD pipelines without actually publishing artifacts. Default value is
+      ``false``.
+    required: false
+    default: false
+    type: string
+
   python-version:
-    description: 'Desired Python version for using twine.'
+    description: >
+      Python version for installing and using `twine
+      <https://twine.readthedocs.io/en/stable/>`_.
     required: false
     default: '3.10'
     type: string
+
 
 runs:
   using: "composite"
@@ -32,3 +64,4 @@ runs:
         twine-username: ${{ inputs.twine-username }}
         twine-token: ${{ inputs.twine-token }}
         python-version: ${{ inputs.python-version }}
+        dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
Fix #138, fix #139 and fix #140 by allowing to download additional artifacts. Related to #178 too.