### PR TITLE
FIX: release-github syntax

### DIFF
--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -137,7 +137,7 @@ runs:
 
     - name: "Release to GitHub"
       uses: softprops/action-gh-release@v1
-      if: ${{ inputs.dry-run != "false" }}
+      if: inputs.dry-run != "false"
       with:
         files: |
           # Include wheel and source distribution artifacts


### PR DESCRIPTION
As per the issues found in https://github.com/ansys/ansys-sphinx-theme/actions/runs/4284451985/jobs/7461503095.