### PR TITLE
Solving bug with Package creation dates

### DIFF
--- a/hk-package-clean-except/action.yml
+++ b/hk-package-clean-except/action.yml
@@ -59,6 +59,8 @@ runs:
         from ghapi.core import print_summary
         from ghapi.page import paged
         
+        PACKAGE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+        
         org_str = "${{ inputs.package-org }}"
         pck_str = "${{ inputs.package-name }}"
         last_days_str = "${{ inputs.allow-last-days }}"
@@ -87,7 +89,7 @@ runs:
                 # If keeping last days is requested, then check
                 if (
                     last_days
-                    and datetime.fromisoformat(package.created_at).timestamp()
+                    and datetime.strptime(package.created_at, PACKAGE_TIME_FORMAT).timestamp()
                     < delete_before_date.timestamp()
                 ):
                     continue

--- a/hk-package-clean-untagged/action.yml
+++ b/hk-package-clean-untagged/action.yml
@@ -55,6 +55,8 @@ runs:
         from ghapi.core import print_summary
         from ghapi.page import paged
         
+        PACKAGE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+        
         org_str = "${{ inputs.package-org }}"
         pck_str = "${{ inputs.package-name }}"
         last_days_str = "${{ inputs.allow-last-days }}"
@@ -80,7 +82,7 @@ runs:
                 # If keeping last days is requested, then check
                 if (
                     last_days
-                    and datetime.fromisoformat(package.created_at).timestamp()
+                    and datetime.strptime(package.created_at, PACKAGE_TIME_FORMAT).timestamp()
                     < delete_before_date.timestamp()
                 ):
                     continue


### PR DESCRIPTION
Reported by @greschd. Previous implementation was only working with Python 3.11. This one should work everywhere.