### PR TITLE
chore: force dependabot to follow commit style

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "maint"
+      prefix: "build"
     labels:
       - "maintenance"
       - "dependencies"
@@ -15,6 +15,6 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "maint"
+      prefix: "build"
     labels:
       - "maintenance"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/requirements"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "maint"
     labels:
       - "maintenance"
       - "dependencies"
@@ -12,5 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "maint"
     labels:
       - "maintenance"


### PR DESCRIPTION
As per pull-request title, this ensures that dependabot opens any pull request following the "maint: ..." title.