### PR TITLE
feat: add generate sitemap action

### DIFF
--- a/_doc-gen-sitemap/action.yml
+++ b/_doc-gen-sitemap/action.yml
@@ -53,7 +53,7 @@ runs:
         # Add URLs to the sitemap
         echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" > $output
         echo "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" >> $output
-        
+
         # Add homepage
         echo "  <url>" >> $output
         echo "    <loc>$website</loc>" >> $output
@@ -61,7 +61,7 @@ runs:
         echo "    <changefreq>daily</changefreq>" >> $output
         echo "    <priority>1.0</priority>" >> $output
         echo "  </url>" >> $output
-        
+
         # Add other URLs
         while IFS= read -r -d '' file; do
           url=${file#$input_dir}
@@ -73,6 +73,6 @@ runs:
           echo "    <priority>0.5</priority>" >> $output
           echo "  </url>" >> $output
         done < <(find "$input_dir" -type f -name "*.html" -print0)
-        
+
         # Close the sitemap
         echo "</urlset>" >> $output

--- a/_doc-gen-sitemap/action.yml
+++ b/_doc-gen-sitemap/action.yml
@@ -1,0 +1,78 @@
+name: >
+  Doc deploy dev action
+
+description: |
+  This action deploys the desired HTML documentation artifact containing the
+  development version of a library to the specified branch of a repository. By
+  default, the ``gh-pages`` branch of the current repository is assumed.
+
+  .. note::
+
+      If your project is using ``pyansys/actions@v3`` or lower and you would
+      like to update to this version of the actions, see the `guidelines for
+      migrating to the latest multi-version documentation layout
+      <https://dev.docs.pyansys.com/how-to/documenting.html#multi-version-migration-from-pyansys-actions-v3-to-pyansys-actions-v4>`_ .
+
+inputs:
+
+  # Required inputs
+
+  cname:
+    description: >
+      The canonical name (CNAME) containing the documentation.
+    required: true
+    type: string
+
+  html-directory:
+    description: >
+      Name of the directory containing the HTML files of the website.
+    required: true
+    type: string
+
+
+runs:
+  using: "composite"
+  steps:
+
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Generating the XML sitemap.
+
+    - name: "Generate the sitemap.xml file"
+      shell: bash
+      run: |
+        # Declare the website name and the output file for the sitemap
+        website="https://www.${{ inputs.cname }}"
+        input_dir=${{ inputs.html-directory }}
+        output="sitemap.xml"
+
+        # Add URLs to the sitemap
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" > $output
+        echo "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" >> $output
+        
+        # Add homepage
+        echo "  <url>" >> $output
+        echo "    <loc>$website</loc>" >> $output
+        echo "    <lastmod>$(date +%Y-%m-%dT%H:%M:%S+00:00)</lastmod>" >> $output
+        echo "    <changefreq>daily</changefreq>" >> $output
+        echo "    <priority>1.0</priority>" >> $output
+        echo "  </url>" >> $output
+        
+        # Add other URLs
+        while IFS= read -r -d '' file; do
+          url=${file#$input_dir}
+          url=${url%.html}
+          echo "  <url>" >> $output
+          echo "    <loc>$website$url</loc>" >> $output
+          echo "    <lastmod>$(date +%Y-%m-%dT%H:%M:%S+00:00)</lastmod>" >> $output
+          echo "    <changefreq>weekly</changefreq>" >> $output
+          echo "    <priority>0.5</priority>" >> $output
+          echo "  </url>" >> $output
+        done < <(find "$input_dir" -type f -name "*.html" -print0)
+        
+        # Close the sitemap
+        echo "</urlset>" >> $output

--- a/_doc-gen-sitemap/action.yml
+++ b/_doc-gen-sitemap/action.yml
@@ -1,17 +1,11 @@
 name: >
-  Doc deploy dev action
+  Documentation sitemap generator
 
 description: |
-  This action deploys the desired HTML documentation artifact containing the
-  development version of a library to the specified branch of a repository. By
-  default, the ``gh-pages`` branch of the current repository is assumed.
-
-  .. note::
-
-      If your project is using ``pyansys/actions@v3`` or lower and you would
-      like to update to this version of the actions, see the `guidelines for
-      migrating to the latest multi-version documentation layout
-      <https://dev.docs.pyansys.com/how-to/documenting.html#multi-version-migration-from-pyansys-actions-v3-to-pyansys-actions-v4>`_ .
+  This process creates a ``sitemap.xml`` file, which enhances the search
+  engine's browsing experience of our documentation. The process is a private
+  composite action that is executed as a component of the PyAnsys documentation
+  deployment strategies.
 
 inputs:
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -363,6 +363,21 @@ runs:
       with:
         level: "INFO"
         message: >
+          Generate the site-map for the latest development or stable
+          documentation.
+
+    - name: "Generate 'sitemap.xml' file"
+      uses: pyansys/actions/_doc-gen-sitemap
+      with:
+        cname: ${{ inputs.cname }}
+        html-directory: version/stable
+
+    # ------------------------------------------------------------------------
+
+    - uses: pyansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
           For deploying the documentation, a GitHub token or a deployment token
           is required. The GitHub token is used when deploying to the current
           repository while the deployment token is used to deploy to an external


### PR DESCRIPTION
Fix #242 by adding an action named `_doc-gen-sitemap` that generates a `sitemap.xml` file when deploying the stable documentation.

You can test this logic locally by using the following shell script:

```bash
#!/bin/bash

cname="actions.docs.pyansys.com"
html_dir="doc/_build/html"
website="https://www.${cname}"
input_dir=${html_dir}
output="sitemap.xml"

# Add URLs to the sitemap
echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" > $output
echo "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" >> $output

# Add homepage
echo "  <url>" >> $output
echo "    <loc>$website</loc>" >> $output
echo "    <lastmod>$(date +%Y-%m-%dT%H:%M:%S+00:00)</lastmod>" >> $output
echo "    <changefreq>daily</changefreq>" >> $output
echo "    <priority>1.0</priority>" >> $output
echo "  </url>" >> $output

# Add other URLs
while IFS= read -r -d '' file; do
  url=${file#$input_dir}
  url=${url%.html}
  echo "  <url>" >> $output
  echo "    <loc>$website$url</loc>" >> $output
  echo "    <lastmod>$(date +%Y-%m-%dT%H:%M:%S+00:00)</lastmod>" >> $output
  echo "    <changefreq>weekly</changefreq>" >> $output
  echo "    <priority>0.5</priority>" >> $output
  echo "  </url>" >> $output
done < <(find "$input_dir" -type f -name "*.html" -print0)

# Close the sitemap
echo "</urlset>" >> $output
```