### PR TITLE
fix: versions page generation

### DIFF
--- a/_doc-gen-versions-page/action.yml
+++ b/_doc-gen-versions-page/action.yml
@@ -85,10 +85,14 @@ runs:
         # desired
         tr -d '\n\r' < $html_file > $tmp_file
 
+        # Retrieve the open and closing tags for the desired element
+        input_tag=${{ inputs.html-tag-content }}
+        close_tag=$(grep -o '<div\b[^>]*>' .$tmp_file | sed 's/<div\( [^>]*)\(.*\)>/\1/')
+        open_tag=$(grep -o '<$html_tag\b[^>]*>' $tmp_file)
+
         # Update the content of the page with the versions
-        html_tag = ${{ inputs.html-tag-content }}
-        sed -i 's#<$html_tag\b[^>]*>.*<\/$html_tag>#<$html_tag><h1>Versions</h1></$html_tag>#g' $tmp_file
-        sed -i "/<h1>/a ${paragraph}\n${table}" index.html
+        sed -i 's|$open_tag.*$close_tag|$open_tag<h1>Versions</h1>$close_tag|g' $tmp_file
+        sed -i "/<h1>/a ${paragraph}\n${table}" $tmp_file
 
         # Restore the style of the HTML file
         tidy -q -indent -ashtml -o $html_file $tmp_file

--- a/_doc-gen-versions-page/action.yml
+++ b/_doc-gen-versions-page/action.yml
@@ -87,8 +87,7 @@ runs:
 
         # Update the content of the page with the versions
         html_tag = ${{ inputs.html-tag-content }}
-        sed -i 's/<${html_tag} .*>.*<\/${html_tag}>/<{$html_tag}><\/${html_tag}>/' $tmp_file
-        sed -i 's/<h1>.*<\/h1>/<h1>Versions<\/h1>/' index.html
+        sed -i 's#<$html_tag\b[^>]*>.*<\/$html_tag>#<$html_tag><h1>Versions</h1></$html_tag>#g' $tmp_file
         sed -i "/<h1>/a ${paragraph}\n${table}" index.html
 
         # Restore the style of the HTML file

--- a/_doc-gen-versions-page/action.yml
+++ b/_doc-gen-versions-page/action.yml
@@ -22,6 +22,14 @@ inputs:
     required: true
     type: string
 
+  html-tag-content:
+    description: >
+      Name of the unique HTML tag that comprises all the content of the article
+      or post.
+    required: true
+    type: string
+
+
 runs:
   using: "composite"
   steps:
@@ -70,11 +78,18 @@ runs:
         # Close the table
         table+="</tbody></table>"
 
-        # Replace the h1 element with "Versions"
-        sed -i 's/<h1>.*<\/h1>/<h1>Versions<\/h1>/' index.html
-
         # Add a paragraph describing the table
         paragraph="<p>This table lists all versions released for the project:</p>"
 
-        # Insert the paragraph and table into the HTML article after the h1 tag
+        # Convert the HTML into a temporary one-line document so 'sed' works as
+        # desired
+        tr -d '\n\r' < $html_file > $tmp_file
+
+        # Update the content of the page with the versions
+        html_tag = ${{ inputs.html-tag-content }}
+        sed -i 's/<${html_tag} .*>.*<\/${html_tag}>/<{$html_tag}><\/${html_tag}>/' $tmp_file
+        sed -i 's/<h1>.*<\/h1>/<h1>Versions<\/h1>/' index.html
         sed -i "/<h1>/a ${paragraph}\n${table}" index.html
+
+        # Restore the style of the HTML file
+        tidy -q -indent -ashtml -o $html_file $tmp_file

--- a/_doc-gen-versions-page/action.yml
+++ b/_doc-gen-versions-page/action.yml
@@ -72,7 +72,7 @@ runs:
         # Loop through the folder array and add each folder name and URL to the table
         for folder in "${folders[@]}"; do
           url="https://${{ inputs.cname }}/version/${folder}"
-          table+="<tr><td>${folder}</td><td>${url}</td></tr>"
+          table+="<tr><td>${folder}</td><td><a href="${url}">${url}</a></td></tr>"
         done
 
         # Close the table
@@ -83,16 +83,18 @@ runs:
 
         # Convert the HTML into a temporary one-line document so 'sed' works as
         # desired
+        tmp_file="tmp_index.html"
         tr -d '\n\r' < $html_file > $tmp_file
 
         # Retrieve the open and closing tags for the desired element
         input_tag=${{ inputs.html-tag-content }}
-        close_tag=$(grep -o '<div\b[^>]*>' .$tmp_file | sed 's/<div\( [^>]*)\(.*\)>/\1/')
-        open_tag=$(grep -o '<$html_tag\b[^>]*>' $tmp_file)
+        close_tag=$(grep -o "<$input_tag\b[^>]*>" "$tmp_file" | sed 's/^<\([[:alnum:]]\{1,\}\)[^>]*>/<\/\1>/g')
+        open_tag=$(grep -o "<$html_tag\b[^>]*>" "$tmp_file")
 
         # Update the content of the page with the versions
-        sed -i 's|$open_tag.*$close_tag|$open_tag<h1>Versions</h1>$close_tag|g' $tmp_file
-        sed -i "/<h1>/a ${paragraph}\n${table}" $tmp_file
+        sed -i "s|$open_tag.*$close_tag|$open_tag<h1>Versions</h1>$close_tag$paragraph$table|g" "$tmp_file"
 
         # Restore the style of the HTML file
+        sudo apt install tidy
         tidy -q -indent -ashtml -o $html_file $tmp_file
+        rm -rf $tmp_file

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -85,6 +85,15 @@ inputs:
     default: true
     type: string
 
+  html-tag-content:
+    description: >
+      Name of the unique HTML tag that comprises all the content of the article
+      or post.
+    required: false
+    default: 'article'
+    type: string
+
+
 runs:
   using: "composite"
   steps:
@@ -227,6 +236,7 @@ runs:
     - uses: pyansys/actions/_doc-gen-versions-page@main
       with:
         cname: ${{ inputs.cname }}
+        html-tag-content: ${{ inputs.html-tag-content }}
 
     # ------------------------------------------------------------------------
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -93,6 +93,15 @@ inputs:
     default: true
     type: string
 
+  html-tag-content:
+    description: >
+      Name of the unique HTML tag that comprises all the content of the article
+      or post.
+    required: false
+    default: 'article'
+    type: string
+
+
 runs:
   using: "composite"
   steps:
@@ -366,6 +375,7 @@ runs:
     - uses: pyansys/actions/_doc-gen-versions-page@main
       with:
         cname: ${{ inputs.cname }}
+        html-tag-content: ${{ inputs.html-tag-content }}
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix #252.

This pull-request guarantees that the content inside of the desired HTML tag gets override in favor of the Versions page. It also makes sure that the URL are actual HTML links by using the `<a>` tag.

I must confess I am not satisfied with this implementation. The reason is that, so far, multi-version documentation is "agnostic" to the theme you are using. That is why we need to accept this HTML tag to exactly now which is the element containing the main information of the page.

Use the following script and HTML file to reproduce locally. Feel free to modify the unique HTML tag containing the main info of the page to see how this works.

```bash
#!/bin/bash

html_file="index.html"
html_tag="section"
cname="cname.com"
tmp_file="temp.html" # Add variable for temporary file

# Create an array of folder names
folders=(*/)
folders=("${folders[@]%/}")

# Get the absolute path of the current directory
abs_path=$(pwd)

# Start building the HTML table
table="<table class=\"table\"><thead><tr><th>Version</th><th>URL</th></tr></thead><tbody>"

# Loop through the folder array and add each folder name and URL to the table
for folder in "${folders[@]}"; do
  url="https://$cname/version/${folder}"
  table+="<tr><td>${folder}</td><td><a href=\"${url}\">${url}</a></td></tr>" # Fix quotes
done

# Close the table
table+="</tbody></table>"

# Add a paragraph describing the table
paragraph="<p>This table lists all versions released for the project:</p>"

# Convert the HTML into a temporary one-line document so 'sed' works as
# desired
tr -d '\n\r' < "$html_file" > "$tmp_file" # Fix quotes

# Retrieve the open and closing tags for the desired element
input_tag="$html_tag" # Fix quotes
#close_tag=$(grep -o "<$input_tag\b[^>]*>" "$tmp_file" | sed "s|<$input_tag\([^>]*\)>|\1|") # Fix quotes and sed command
#close_tag=$(grep -o '<'$input_tag'\b[^>]*>' $tmp_file | sed 's/<'$input_tag'\( [^>]*)\(.*\)>/\1>/')
#close_tag=$(grep -o '<'$input_tag'\b[^>]*>' $tmp_file | sed 's/<'$input_tag'\([^>]*\)>.*/\1/')
close_tag=$(grep -o "<$input_tag\b[^>]*>" "$tmp_file" | sed 's/^<\([[:alnum:]]\{1,\}\)[^>]*>/<\/\1>/g')
open_tag=$(grep -o "<$html_tag\b[^>]*>" "$tmp_file")

echo "Input tag: $input_tag"
echo "Open tag: $open_tag"
echo "Close tag: $close_tag"

# Update the content of the page with the versions
sed -i "s|$open_tag.*$close_tag|$open_tag<h1>Versions</h1>$close_tag$paragraph$table|g" "$tmp_file" # Fix quotes and add variables

# Restore the style of the HTML file
tidy -q -indent -ashtml -o "$html_file" "$tmp_file" # Fix quotes and add variables

# Remove the temporary file
rm "$tmp_file"
```

```html
<!DOCTYPE html>
<html lang="en">
    <head>
        <title></title>
        <meta charset="UTF-8">
        <meta name="viewport" content="width=device-width, initial-scale=1">
        <link href="css/style.css" rel="stylesheet">
    </head>
    <body>
      <section class="bd-article" role="main">
          OLD CONTENT
      </section>
    </body>
</html>
```