### PR TITLE
feat(actions): expose python-path output and propagate it to build-wheelhouse

### DIFF
--- a/_setup-python/action.yml
+++ b/_setup-python/action.yml
@@ -50,6 +50,11 @@ inputs:
     required: true
     type: boolean
 
+outputs:
+  python-path:
+    description: "The path to the Python executable"
+    value: ${{ steps.python-path.outputs.PYTHON_PATH }}
+
 runs:
   using: "composite"
   steps:
@@ -102,3 +107,13 @@ runs:
       with:
         enable-cache: ${{ inputs.use-cache }}
         prune-cache: ${{ inputs.prune-uv-cache }}
+
+    - name: "Get Python path"
+      id: python-path
+      shell: python
+      # Using python shell to ensure compatibility with Windows runners
+      run: |
+        import sys
+        import os
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"PYTHON_PATH={sys.executable}\n")

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -147,6 +147,13 @@ outputs:
       the virtual environment, such as running smoke tests.
     value: ${{ steps.virtual-environment-activation-command.outputs.ACTIVATE_VENV }}
 
+  python-path:
+    description: |
+      Path to the Python interpreter within the virtual environment set up by this action.
+      It can be reused in later steps of the same job to execute tasks within
+      the virtual environment, such as running smoke tests.
+    value: ${{ steps.setup-python.outputs.python-path }}
+
 runs:
   using: "composite"
   steps:
@@ -158,6 +165,7 @@ runs:
         persist-credentials: false
 
     - name: "Set up Python ${{ inputs.python-version }}"
+      id: setup-python
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -152,7 +152,7 @@ outputs:
       Path to the Python interpreter within the virtual environment set up by this action.
       It can be reused in later steps of the same job to execute tasks within
       the virtual environment, such as running smoke tests.
-    value: ${{ steps.setup-python.outputs.python-path }}
+    value: ${{ steps.virtual-environment-python-path.outputs.PYTHON_PATH }}
 
 runs:
   using: "composite"
@@ -250,6 +250,13 @@ runs:
         else
           echo "ACTIVATE_VENV=$(echo 'source .venv/bin/activate')" >> $GITHUB_OUTPUT
         fi
+
+    - name: "Set up python path output"
+      id: virtual-environment-python-path
+      shell: bash
+      run: |
+        ${ACTIVATE_VENV}
+        python -c "import sys,os;f=open(os.environ['GITHUB_OUTPUT'],'a');f.write(f'PYTHON_PATH={sys.executable}\n');f.close()"
 
     - name: "Update pip"
       shell: bash

--- a/doc/source/changelog/1038.added.md
+++ b/doc/source/changelog/1038.added.md
@@ -1,0 +1,1 @@
+Expose python-path output and propagate it to build-wheelhouse


### PR DESCRIPTION
I believe it makes more sense to export the `python` path, so it can be used as an env var:

```yml
- name: "Build wheelhouse"
  uses: ansys/actions/build-wheelhouse@main
  with:
    library-name: ${{ env.LIBRARY_NAME }}
    operating-system: ${{ matrix.os }}
    python-version: ${{ env.MAIN_PYTHON_VERSION }}
    working-directory: .ci/${{ env.LIBRARY_NAME }}
    attest-provenance: true

- name: "do something..."
  env:
    PYTHON: ${{ steps.build-wheelhouse.output.python-path }}
  run:
    python something.py
```

Potentially you could do (I will need a double check):

```yml
- name: "do something..."
  shell: python
  env:
    PYTHON: ${{ steps.build-wheelhouse.output.python-path }}
  run:
    # my python code
    from ansys.mapdl.core import launch_mapdl
```

Or **maybe** we can do something like:

```yml
- name: "do something..."
  shell: ${{ steps.build-wheelhouse.output.python-path }} {0}
  run:
    # my python code
    from ansys.mapdl.core import launch_mapdl
```



## Changes
- Add python-path output and a "Get Python path" step to the _setup-python composite action.
- Add id: setup-python to the build-wheelhouse setup step and expose python-path via steps.setup-python.outputs.python-path.