### PR TITLE
fix: typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ facilitate an understanding of the Ansys Actions code repository.
 
 For contributing to this project, please refer to the [PyAnsys Developer's
 Guide]. Further information about this project can be found
-in the [official docuementation].
+in the [official documentation].
 
 [PyAnsys Developer's Guide]: https://dev.docs.pyansys.com
 [official documentation]: https://actions.docs.ansys.com


### PR DESCRIPTION
Fixes a typo that breaks a link in the `CONTRIBUTING.md` file.