### PR TITLE
refactor: use actions/attest instead of actions/attest-build-provenance

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -216,6 +216,6 @@ runs:
 
     - name: Generate build provenance attestation
       if: inputs.attest-provenance == 'true'
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-path: dist/

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -374,7 +374,7 @@ runs:
 
     - name: Generate build provenance attestation
       if: ${{ inputs.attest-provenance == 'true' }}
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-path: ${{ steps.sanitize.outputs.sanitized_library_name }}-v${{ steps.library-version.outputs.library_version }}-${{ steps.specific-target-requested.outputs.wheelhouse_target }}-${{ inputs.operating-system }}-${{ inputs.python-version }}-sbom.spdx
 
@@ -421,7 +421,7 @@ runs:
 
     - name: Generate build provenance attestation
       if: inputs.attest-provenance == 'true'
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
         subject-path: ${{ steps.sanitize.outputs.sanitized_library_name }}-v${{ steps.library-version.outputs.library_version }}-${{ steps.specific-target-requested.outputs.wheelhouse_target }}-${{ inputs.operating-system }}-${{ inputs.python-version }}.zip
 

--- a/doc/source/changelog/1247.miscellaneous.md
+++ b/doc/source/changelog/1247.miscellaneous.md
@@ -1,0 +1,1 @@
+Use actions/attest insteaf of actions/attest-build-provenance

--- a/doc/source/changelog/1247.miscellaneous.md
+++ b/doc/source/changelog/1247.miscellaneous.md
@@ -1,1 +1,1 @@
-Use actions/attest insteaf of actions/attest-build-provenance
+Use actions/attest instead of actions/attest-build-provenance


### PR DESCRIPTION
Since version `4.0.0` the action `actions/attest-build-provenance` is simply a wrapper around [actions/attest](https://github.com/actions/attest). Moving to the "main" action should prevent us from missing new updates if the synchronization is not performed on `actions/attest-build-provenance` side.

See https://github.com/actions/attest-build-provenance#usage or https://github.com/actions/attest-build-provenance/pull/835/changes#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6
