### PR TITLE
chore: bump zizmor version

### DIFF
--- a/check-actions-security/action.yml
+++ b/check-actions-security/action.yml
@@ -122,6 +122,12 @@ runs:
       run: |
         cat << _EOF_ > zizmor.yml
         rules:
+          secrets-outside-env:
+            disable: true
+
+          superfluous-actions:
+            disable: true
+
           unpinned-uses:
             config:
               policies:

--- a/check-actions-security/action.yml
+++ b/check-actions-security/action.yml
@@ -92,7 +92,7 @@ runs:
     - name: "Install zizmor and verify installation"
       shell: bash
       run: |
-        uv tool install zizmor==1.16.0
+        uv tool install zizmor==1.23.1
         zizmor --version
 
     - name: "Optionally set GH_TOKEN"

--- a/check-actions-security/zizmor.yml
+++ b/check-actions-security/zizmor.yml
@@ -21,14 +21,14 @@
 # SOFTWARE.
 
 rules:
-  unpinned-uses:
-    config:
-      policies:
-        ansys/*: ref-pin
-        actions/*: hash-pin
-
   secrets-outside-env:
     disable: true
 
   superfluous-actions:
     disable: true
+
+  unpinned-uses:
+    config:
+      policies:
+        ansys/*: ref-pin
+        actions/*: hash-pin

--- a/check-actions-security/zizmor.yml
+++ b/check-actions-security/zizmor.yml
@@ -26,3 +26,9 @@ rules:
       policies:
         ansys/*: ref-pin
         actions/*: hash-pin
+
+  secrets-outside-env:
+    disable: true
+
+  superfluous-actions:
+    disable: true

--- a/doc/source/changelog/1252.maintenance.md
+++ b/doc/source/changelog/1252.maintenance.md
@@ -1,0 +1,1 @@
+Bump zizmor version


### PR DESCRIPTION
Bumping the version of zizmor in preparation for `v10.3` release.

We already had a discussion about not enforcing `secrets-outside-env`.

As for `superfluous-actions`, I think disabling it also makes sense, otherwise it forces using cli tools in place of some popular actions. For example, using `gh release create` in place of `softprops/action-gh-release` and using `gh pr/issue comment` in place of `peter-evans/create-or-update-comment`. Enforcing such a shift will cause significant friction (not everyone is familiar with using cli tools for example, among other things).