### PR TITLE
feat: sbom and wheelhouse filtering on GitHub release

### DIFF
--- a/doc/source/changelog/1260.added.md
+++ b/doc/source/changelog/1260.added.md
@@ -1,1 +1,1 @@
-Sbom and wheelhouse filtering on gh release
+Sbom and wheelhouse filtering on GitHub release

--- a/doc/source/changelog/1260.added.md
+++ b/doc/source/changelog/1260.added.md
@@ -1,0 +1,1 @@
+Sbom and wheelhouse filtering on gh release

--- a/python-utils/release_github_utils.py
+++ b/python-utils/release_github_utils.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import fnmatch
 import re
 from pathlib import Path
 
@@ -157,3 +158,29 @@ def get_release_notes(pyproject_path: Path):
 
     # Save the env variable
     save_env_variable("RELEASE_NOTES_BODY", body)
+
+
+def filter_dist_files(dist_filter: str) -> None:
+    """Filter files in wheelhouse and SBOM distribution directories.
+
+    Files that do not match any of the provided glob patterns are deleted.
+
+    Parameters
+    ----------
+    dist_filter: str
+        Comma-separated list of glob patterns to keep (e.g. ``'*all*,*graphics*'``).
+    """
+    directories = [Path("dist/wheelhouse"), Path("dist/sbom")]
+
+    patterns = [p.strip() for p in dist_filter.split(",") if p.strip()]
+
+    for directory in directories:
+        if not directory.is_dir():
+            continue
+        print(f"Filtering in {directory} with patterns: {dist_filter}")
+        for file in directory.rglob("*"):
+            if not file.is_file():
+                continue
+            if not any(fnmatch.fnmatch(file.name, pattern) for pattern in patterns):
+                print(f"  Removing: {file}")
+                file.unlink()

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -329,25 +329,6 @@ runs:
 
     # ------------------------------------------------------------------------
 
-    - name: "Filter SBOM or wheelhouse files (if needed)"
-      if: inputs.dist-filter != ''
-      shell: python
-      env:
-        DIST_FILTER: ${{ inputs.dist-filter }}
-      run: |
-        import os
-        import sys
-
-        github_action_path = os.getenv("GITHUB_ACTION_PATH")
-        sys.path.insert(1, f'{github_action_path}/../python-utils/')
-
-        from release_github_utils import filter_dist_files
-
-        dist_filter = os.getenv("DIST_FILTER")
-        filter_dist_files(dist_filter)
-
-    # ------------------------------------------------------------------------
-
     - uses: ansys/actions/_logging@main
       if: inputs.only-code == 'false'
       with:
@@ -447,7 +428,7 @@ runs:
       with:
         level: "INFO"
         message: >
-          Display the structure of the 'dist/' folder. Upload all artifacts.
+          Display the structure of the 'dist/' folder. Upload artifacts.
 
     - name: "Display the structure of the 'dist/' folder"
       shell: bash
@@ -470,6 +451,23 @@ runs:
       run: |
         ${INSTALL_COMMAND} --upgrade pip tomlkit=="$TOMLKIT_VERSION"
         ${INSTALL_COMMAND} pypandoc-binary=="$PYPANDOC_BINARY_VERSION"
+
+    - name: "Filter SBOM or wheelhouse files (if needed)"
+      if: inputs.dist-filter != ''
+      shell: python
+      env:
+        DIST_FILTER: ${{ inputs.dist-filter }}
+      run: |
+        import os
+        import sys
+
+        github_action_path = os.getenv("GITHUB_ACTION_PATH")
+        sys.path.insert(1, f'{github_action_path}/../python-utils/')
+
+        from release_github_utils import filter_dist_files
+
+        dist_filter = os.getenv("DIST_FILTER")
+        filter_dist_files(dist_filter)
 
     - name: "Get the release notes body"
       if: inputs.changelog-release-notes == 'true'

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -469,6 +469,11 @@ runs:
         dist_filter = os.getenv("DIST_FILTER")
         filter_dist_files(dist_filter)
 
+    - name: "Display the structure of the 'dist/' folder after filtering"
+      if: inputs.dist-filter != ''
+      shell: bash
+      run: ls -R dist/
+
     - name: "Get the release notes body"
       if: inputs.changelog-release-notes == 'true'
       shell: python

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -187,6 +187,16 @@ inputs:
     required: false
     type: boolean
 
+  dist-filter:
+    description: |
+      Comma-separated list of glob patterns to keep in the ``dist/wheelhouse`` and ``dist/sbom``
+      directories, for example ``'*all*,*graphics*'``. All files that do not match any of
+      the provided patterns are deleted after those directories are populated.
+      Default value is ``''``, in which case no filtering is applied.
+    required: false
+    default: ''
+    type: string
+
 runs:
   using: "composite"
   steps:
@@ -316,6 +326,25 @@ runs:
       run: |
         mkdir -p dist/sbom
         mv /tmp/artifacts/**/*-sbom.spdx dist/sbom/
+
+    # ------------------------------------------------------------------------
+
+    - name: "Filter SBOM or wheelhouse files (if needed)"
+      if: inputs.dist-filter != ''
+      shell: python
+      env:
+        DIST_FILTER: ${{ inputs.dist-filter }}
+      run: |
+        import os
+        import sys
+
+        github_action_path = os.getenv("GITHUB_ACTION_PATH")
+        sys.path.insert(1, f'{github_action_path}/../python-utils/')
+
+        from release_github_utils import filter_dist_files
+
+        dist_filter = os.getenv("DIST_FILTER")
+        filter_dist_files(dist_filter)
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds support for filtering distribution files in the `dist/wheelhouse` and `dist/sbom` directories when releasing on Github. 
The main reason for this change is that the combinatorial associated to the build-wheelhouse action can lead to a releases page heavily loaded, making it hard for users to find the artifact they would like to consume. Below is an example in pyaedt 
<img width="1141" height="739" alt="image" src="https://github.com/user-attachments/assets/39f7c7c0-3d4b-42dc-be9c-d0b4705242a6" />
where not all items are showing AND where we have been discarding the wheelhouses without optional target. This is because most (if not all) of our users request the wheelhouse with `all` target. 

While removing the wheelhouses without optional target reduces the number of artifact, it can also lead to a release that is not working without an optional dependency installed :/ This scenario happened in a release of `pyaedt` where the command `import ansys.aedt.core` was failing due to a graphic dependency being required. This error went through the CI because we removed the target '' from the build-wheelhouse job as we didn't want to many artifacts in the releases page...

The proposed feature would help to keep having the full build-wheelhouse job and filtering what gets into the releases page.

---

[Here](https://github.com/SMoraisAnsys/ansys-tools-visualization-interface/releases) is a successful run where I played with the filter `"*ubuntu-latest*,*windows-latest-3.12*,*-all-wheelhouse-macos-latest-3.14*"` and which worked as expected.