### PR TITLE
feat(build-wheelhouse):  add opt-in inputs to fetch full git history & tags for versioning

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -149,6 +149,20 @@ inputs:
     required: false
     type: boolean
 
+  checkout-fetch-depth:
+    description: |
+      Set fetch-depth option for actions/checkout. Default value is ``1``.
+    required: false
+    default: '1'
+    type: string
+
+  checkout-fetch-tags:
+    description: |
+      Set fetch-tags option for actions/checkout. Default value is ``false``.
+    required: false
+    default: false
+    type: boolean
+
 outputs:
 
   activate-venv:
@@ -167,6 +181,8 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+        fetch-depth: ${{ inputs.checkout-fetch-depth }}
+        fetch-tags: ${{ inputs.checkout-fetch-tags }}
 
     - name: "Set up Python ${{ inputs.python-version }}"
       uses: ansys/actions/_setup-python@main

--- a/doc/source/changelog/1269.added.md
+++ b/doc/source/changelog/1269.added.md
@@ -1,0 +1,1 @@
+Add opt-in inputs to fetch full git history & tags for versioning


### PR DESCRIPTION
Similar to https://github.com/ansys/actions/pull/1024



### Why
I am modifying pydynamicreporting to obtain its package version from Git metadata using **[hatch-vcs](https://github.com/ofek/hatch-vcs)**.   The existing build action performs a **shallow checkout** (`fetch-depth: 1`) and **does not fetch tags**, which prevents Hatch’s VCS plugin from detecting version tags during `python -m build`.   As a result, the build falls back to a default `0.1` version instead of the actual version to be obtained from git tags.

### What changed
- Added two **optional, pass-through** inputs to the composite action’s checkout step:
  - `checkout-fetch-depth` (default: `'1'`)
  - `checkout-fetch-tags` (default: `'false'`)
- These map directly to [`actions/checkout`](https://github.com/actions/checkout) inputs, allowing repositories to **opt in** to fetching full Git history and tags when required.
- Default behavior remains unchanged to avoid side effects for existing consumers.

### Backwards compatibility
- **No breaking changes** — all existing workflows should continue to perform shallow checkouts.
- Projects that require full tag history for VCS-based versioning can explicitly opt in.

### How to opt in (example)
```yaml
- uses: ansys/actions/build-wheelhouse@v10
  with:
    checkout-fetch-depth: '0'    # fetch full history
    checkout-fetch-tags:  'true' # fetch tags for hatch-vcs
```

> **Note:** Hatch’s `vcs` or `vcs-dev` version sources rely on both commit history and annotated tags.  
> Use `fetch-depth: 0` **together** with `fetch-tags: true` to ensure accurate version resolution.

### When this is needed
- Projects using:
  - [hatch-vcs](https://github.com/ofek/hatch-vcs)
  - Hatch `vcs` or `vcs-dev` version sources
  - `setuptools_scm` or other Git tag–based versioning tools
- Any build logic that uses `git describe`, `git tag`, or commit metadata during build time.