### PR TITLE
refactor(build-library)!: remove checkout opt-in option

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -121,20 +121,6 @@ inputs:
     required: false
     type: boolean
 
-  checkout-fetch-depth:
-    description: |
-      Set fetch-depth option for actions/checkout. Default value is ``1``.
-    required: false
-    default: '1'
-    type: string
-
-  checkout-fetch-tags:
-    description: |
-      Set fetch-tags option for actions/checkout. Default value is ``false``.
-    required: false
-    default: false
-    type: boolean
-
 runs:
   using: "composite"
   steps:
@@ -144,8 +130,6 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-        fetch-depth: ${{ inputs.checkout-fetch-depth }}
-        fetch-tags:  ${{ inputs.checkout-fetch-tags }}
 
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main

--- a/doc/source/changelog/1280.breaking.md
+++ b/doc/source/changelog/1280.breaking.md
@@ -1,0 +1,1 @@
+Remove checkout opt-in option


### PR DESCRIPTION
Follow up of the discussion in https://github.com/ansys/actions/pull/1269

The rationale behind these changes is that:
- these options haven't been used in our repos despite being public for multiple months. In fact, even the maintainer that was suggesting such changes doesn't seem to be using them, see this [ref](https://github.com/ansys/pydynamicreporting/blob/main/.github/workflows/ci_cd.yml#L106-L120)
- since we allow one to disable `actions/checkout` to perform a custom checkout, the options under consideration have no use. In fact, that's how things are being handled in the link above...

@moe-ad Depending on how we want to release those changes, we might have to wait for the next major release.