### PR TITLE
chore: ignoring cookiecutter from vale

### DIFF
--- a/doc/source/changelog/1294.maintenance.md
+++ b/doc/source/changelog/1294.maintenance.md
@@ -1,0 +1,1 @@
+Ignoring cookiecutter from vale

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -3,6 +3,7 @@ ansys
 automerge
 Chocolatey
 CI
+[Cc]ookiecutter
 cooldown
 dependabot
 dev


### PR DESCRIPTION
As title says - seeing failures after the release