### PR TITLE
fix: if miktex is available then make use of it

### DIFF
--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -218,6 +218,15 @@ runs:
         } elseif (Test-Path $systemMiKTeX) {
           Write-Host "MiKTeX already installed at system level, using existing installation."
           echo "$systemMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          # Check if MikTex works by requesting its version
+          $miktexVersion = & "$systemMiKTeX\miktex.exe" --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "Existing MiKTeX installation at system level is not working properly, installing it at user level..."
+            choco install miktex --params '"/Set:basic /ThisUser"' -y
+            echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          } else {
+            Write-Host "Existing MiKTeX installation at system level is working properly."
+          }
         } else {
           # NOTE: Install at user level to avoid errors when running on self-hosted runners
           # where choco was already installed at system level.

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -202,34 +202,35 @@ runs:
     - name: Install MiKTeX and update PATH with MiKTeX binaries
       shell: powershell
       run: | # zizmor: ignore[github-env]
+        # NOTE: Declared at script scope so it can be accessed inside function
+        $script:userMiKTeX = "$env:LocalAppData\Programs\MiKTeX\miktex\bin\x64"
+
         function Invoke-MiKTeXCheck {
           param(
             [string]$InstallPath,
             [string]$Level,
-            [string]$UserInstallPath
           )
           Write-Host "MiKTeX already installed at $Level level, using existing installation."
           $miktexVersion = & "$InstallPath\miktex.exe" --version
           if ($LASTEXITCODE -ne 0) {
             Write-Host "Existing MiKTeX installation at $Level level is not working properly, reinstalling it at user level..."
             choco install miktex --params '"/Set:basic /ThisUser"' -y --force
-            echo "$UserInstallPath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+            echo "$script:userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           } else {
             Write-Host "Existing MiKTeX installation at $Level level is working properly (version: $miktexVersion)."
             echo "$InstallPath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           }
         }
 
-        $userMiKTeX = "$env:LocalAppData\Programs\MiKTeX\miktex\bin\x64"
         $systemMiKTeX = "C:\Program Files\MiKTeX\miktex\bin\x64"
-        if (Test-Path "$userMiKTeX\miktex.exe") {
-          Invoke-MiKTeXCheck -InstallPath $userMiKTeX -Level "user" -UserInstallPath $userMiKTeX
+        if (Test-Path "$script:userMiKTeX\miktex.exe") {
+          Invoke-MiKTeXCheck -InstallPath $script:userMiKTeX -Level "user"
         } elseif (Test-Path "$systemMiKTeX\miktex.exe") {
-          Invoke-MiKTeXCheck -InstallPath $systemMiKTeX -Level "system" -UserInstallPath $userMiKTeX
+          Invoke-MiKTeXCheck -InstallPath $systemMiKTeX -Level "system"
         } else {
           Write-Host "MiKTeX is not installed, installing it at user level..."
           choco install miktex --params '"/Set:basic /ThisUser"' -y
-          echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "$script:userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         }
 
     - name: "Install Poppler for PDF to PNG conversion"

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -202,35 +202,32 @@ runs:
     - name: Install MiKTeX and update PATH with MiKTeX binaries
       shell: powershell
       run: | # zizmor: ignore[github-env]
+        function Invoke-MiKTeXCheck {
+          param(
+            [string]$InstallPath,
+            [string]$Level,
+            [string]$UserInstallPath
+          )
+          Write-Host "MiKTeX already installed at $Level level, using existing installation."
+          $miktexVersion = & "$InstallPath\miktex.exe" --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "Existing MiKTeX installation at $Level level is not working properly, reinstalling it at user level..."
+            choco install miktex --params '"/Set:basic /ThisUser"' -y --force
+            echo "$UserInstallPath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          } else {
+            Write-Host "Existing MiKTeX installation at $Level level is working properly (version: $miktexVersion)."
+            echo "$InstallPath" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          }
+        }
+
         $userMiKTeX = "$env:LocalAppData\Programs\MiKTeX\miktex\bin\x64"
         $systemMiKTeX = "C:\Program Files\MiKTeX\miktex\bin\x64"
-        if (Test-Path $userMiKTeX) {
-          Write-Host "MiKTeX already installed at user level, using existing installation."
-          # Check if MikTex works by requesting its version
-          $miktexVersion = & "$userMiKTeX\miktex.exe" --version
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "Existing MiKTeX installation at user level is not working properly, reinstalling it..."
-            choco install miktex --params '"/Set:basic /ThisUser"' -y --force
-          } else {
-            Write-Host "Existing MiKTeX installation at user level is working properly."
-          }
-          echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-        } elseif (Test-Path $systemMiKTeX) {
-          Write-Host "MiKTeX already installed at system level, using existing installation."
-          echo "$systemMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          # Check if MikTex works by requesting its version
-          $miktexVersion = & "$systemMiKTeX\miktex.exe" --version
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "Existing MiKTeX installation at system level is not working properly, installing it at user level..."
-            choco install miktex --params '"/Set:basic /ThisUser"' -y
-            echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          } else {
-            Write-Host "Existing MiKTeX installation at system level is working properly."
-          }
+        if (Test-Path "$userMiKTeX\miktex.exe") {
+          Invoke-MiKTeXCheck -InstallPath $userMiKTeX -Level "user" -UserInstallPath $userMiKTeX
+        } elseif (Test-Path "$systemMiKTeX\miktex.exe") {
+          Invoke-MiKTeXCheck -InstallPath $systemMiKTeX -Level "system" -UserInstallPath $userMiKTeX
         } else {
-          # NOTE: Install at user level to avoid errors when running on self-hosted runners
-          # where choco was already installed at system level.
-          # For more information, see https://github.com/ansys/actions/pull/1233
+          Write-Host "MiKTeX is not installed, installing it at user level..."
           choco install miktex --params '"/Set:basic /ThisUser"' -y
           echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         }

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -202,11 +202,29 @@ runs:
     - name: Install MiKTeX and update PATH with MiKTeX binaries
       shell: powershell
       run: | # zizmor: ignore[github-env]
-        # NOTE: Install at user level to avoid errors when running on self-hosted runners
-        # where choco was already installed at system level.
-        # For more information, see https://github.com/ansys/actions/pull/1233
-        choco install miktex --params '"/Set:basic /ThisUser"' -y
-        echo "$env:LocalAppData\Programs\MiKTeX\miktex\bin\x64" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        $userMiKTeX = "$env:LocalAppData\Programs\MiKTeX\miktex\bin\x64"
+        $systemMiKTeX = "C:\Program Files\MiKTeX\miktex\bin\x64"
+        if (Test-Path $userMiKTeX) {
+          Write-Host "MiKTeX already installed at user level, using existing installation."
+          # Check if MikTex works by requesting its version
+          $miktexVersion = & "$userMiKTeX\miktex.exe" --version
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "Existing MiKTeX installation at user level is not working properly, reinstalling it..."
+            choco install miktex --params '"/Set:basic /ThisUser"' -y --force
+          } else {
+            Write-Host "Existing MiKTeX installation at user level is working properly."
+          }
+          echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        } elseif (Test-Path $systemMiKTeX) {
+          Write-Host "MiKTeX already installed at system level, using existing installation."
+          echo "$systemMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        } else {
+          # NOTE: Install at user level to avoid errors when running on self-hosted runners
+          # where choco was already installed at system level.
+          # For more information, see https://github.com/ansys/actions/pull/1233
+          choco install miktex --params '"/Set:basic /ThisUser"' -y
+          echo "$userMiKTeX" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        }
 
     - name: "Install Poppler for PDF to PNG conversion"
       if: ${{ inputs.needs-quarto == 'true' }}

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -208,7 +208,7 @@ runs:
         function Invoke-MiKTeXCheck {
           param(
             [string]$InstallPath,
-            [string]$Level,
+            [string]$Level
           )
           Write-Host "MiKTeX already installed at $Level level, using existing installation."
           $miktexVersion = & "$InstallPath\miktex.exe" --version

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -265,7 +265,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@main
+      uses: ansys/actions/_doc-build-windows@fix/use-miktex-if-available-on-windows
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -265,7 +265,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@fix/use-miktex-if-available-on-windows
+      uses: ansys/actions/_doc-build-windows@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc/source/changelog/1305.fixed.md
+++ b/doc/source/changelog/1305.fixed.md
@@ -1,0 +1,1 @@
+If miktex is available then make use of it


### PR DESCRIPTION
Reported in https://github.com/ansys/pysherlock/pull/778

If MikTex is installed already at system level, the new action implementation causes it to fail since we simply take it from the local installation. Let's make it more "dynamic"

1) Verify if MikTex is already there - if so, use it
2) If the available installs of MikTex are corrupt - reinstall at local user level
2) If MikTex is not installed - then use the local user install