### PR TITLE
feat: accepting caio package

### DIFF
--- a/check-licenses/ignored-packages.txt
+++ b/check-licenses/ignored-packages.txt
@@ -1,6 +1,7 @@
 aiohappyeyeballs
 ansys-corba
 ansys-turbogrid-api
+caio
 cmocean
 cookiecutter
 defusedxml

--- a/doc/source/changelog/1306.added.md
+++ b/doc/source/changelog/1306.added.md
@@ -1,0 +1,1 @@
+Accepting caio package

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -1,6 +1,7 @@
 Ansys
 ansys
 automerge
+caio
 Chocolatey
 CI
 [Cc]ookiecutter


### PR DESCRIPTION
The following package has an Apache 2.0 license although for many of the older versions, the license is not shipped properly as part of the metadata.. let's allow for them as well.

See https://github.com/mosquito/caio/blob/master/COPYING for the License file