### PR TITLE
feat: allow skipping python setup

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -131,9 +131,8 @@ inputs:
 
       .. warning::
 
-          The python version available in the environment must match the
-          version specified in the ``python-version`` input. If not, the
-          action will fail.
+          When this option is enabled, the ``python-version`` input is ignored.
+          The Python version already available in the environment is used as-is.
 
     required: false
     default: false
@@ -158,26 +157,12 @@ runs:
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
 
-    - name: "Check Python version matches expected version"
+    - uses: ansys/actions/_logging@main
       if: ${{ inputs.skip-python-setup == 'true' }}
-      shell: bash
-      env:
-        EXPECTED_VERSION: ${{ inputs.python-version }}
-      run: |
-        RAW_VERSION=$(python --version 2>&1)
-        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
-        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
-          echo "::error::No Python interpreter found on PATH."
-          exit 1
-        fi
-        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
-        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
-        # Compare only the specified number of parts to allow for flexibility in patch versions.
-        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
-        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
-          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
-          exit 1
-        fi
+      with:
+        level: "INFO"
+        message: >
+          Skipping Python setup to use system Python.
 
     - name: "Install library"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -128,6 +128,13 @@ inputs:
       and the Python version already available in the environment is used.
       This is useful when a specific Python installation is already on the
       ``PATH`` and the setup step would override it.
+
+      .. warning::
+
+          The python version available in the environment must match the
+          version specified in the ``python-version`` input. If not, the
+          action will fail.
+
     required: false
     default: false
     type: boolean
@@ -150,6 +157,27 @@ runs:
         use-cache: ${{ inputs.use-python-cache }}
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
+
+    - name: "Check Python version matches expected version"
+      if: ${{ inputs.skip-python-setup == 'true' }}
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.python-version }}
+      run: |
+        RAW_VERSION=$(python --version 2>&1)
+        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
+        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
+          echo "::error::No Python interpreter found on PATH."
+          exit 1
+        fi
+        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
+        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
+        # Compare only the specified number of parts to allow for flexibility in patch versions.
+        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
+        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
+          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
+          exit 1
+        fi
 
     - name: "Install library"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -121,6 +121,17 @@ inputs:
     required: false
     type: boolean
 
+  skip-python-setup:
+    description: |
+      Whether to skip the Python setup step performed by
+      ``ansys/actions/_setup-python``. If ``true``, the setup step is skipped
+      and the Python version already available in the environment is used.
+      This is useful when a specific Python installation is already on the
+      ``PATH`` and the setup step would override it.
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -131,7 +142,8 @@ runs:
       with:
         persist-credentials: false
 
-    - name: "Set up Python"
+    - name: "Set up Python ${{ inputs.python-version }}"
+      if: ${{ inputs.skip-python-setup == 'false' }}
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -149,6 +149,17 @@ inputs:
     required: false
     type: boolean
 
+  skip-python-setup:
+    description: |
+      Whether to skip the Python setup step performed by
+      ``ansys/actions/_setup-python``. If ``true``, the setup step is skipped
+      and the Python version already available in the environment is used.
+      This is useful when a specific Python installation is already on the
+      ``PATH`` and the setup step would override it.
+    required: false
+    default: false
+    type: boolean
+
 outputs:
 
   activate-venv:
@@ -169,6 +180,7 @@ runs:
         persist-credentials: false
 
     - name: "Set up Python ${{ inputs.python-version }}"
+      if: ${{ inputs.skip-python-setup == 'false' }}
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -156,6 +156,13 @@ inputs:
       and the Python version already available in the environment is used.
       This is useful when a specific Python installation is already on the
       ``PATH`` and the setup step would override it.
+
+      .. warning::
+
+          The python version available in the environment must match the
+          version specified in the ``python-version`` input. If not, the
+          action will fail.
+
     required: false
     default: false
     type: boolean
@@ -187,6 +194,27 @@ runs:
         use-cache: ${{ inputs.use-python-cache }}
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
+
+    - name: "Check Python version matches expected version"
+      if: ${{ inputs.skip-python-setup == 'true' }}
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.python-version }}
+      run: |
+        RAW_VERSION=$(python --version 2>&1)
+        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
+        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
+          echo "::error::No Python interpreter found on PATH."
+          exit 1
+        fi
+        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
+        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
+        # Compare only the specified number of parts to allow for flexibility in patch versions.
+        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
+        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
+          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
+          exit 1
+        fi
 
     - name: "Identify the build system"
       id: build-system

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -159,9 +159,8 @@ inputs:
 
       .. warning::
 
-          The python version available in the environment must match the
-          version specified in the ``python-version`` input. If not, the
-          action will fail.
+          When this option is enabled, the ``python-version`` input is ignored.
+          The Python version already available in the environment is used as-is.
 
     required: false
     default: false
@@ -195,26 +194,12 @@ runs:
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
 
-    - name: "Check Python version matches expected version"
+    - uses: ansys/actions/_logging@main
       if: ${{ inputs.skip-python-setup == 'true' }}
-      shell: bash
-      env:
-        EXPECTED_VERSION: ${{ inputs.python-version }}
-      run: |
-        RAW_VERSION=$(python --version 2>&1)
-        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
-        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
-          echo "::error::No Python interpreter found on PATH."
-          exit 1
-        fi
-        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
-        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
-        # Compare only the specified number of parts to allow for flexibility in patch versions.
-        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
-        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
-          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
-          exit 1
-        fi
+      with:
+        level: "INFO"
+        message: >
+          Skipping Python setup to use system Python.
 
     - name: "Identify the build system"
       id: build-system

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -223,9 +223,8 @@ inputs:
 
       .. warning::
 
-          The python version available in the environment must match the
-          version specified in the ``python-version`` input. If not, the
-          action will fail.
+          When this option is enabled, the ``python-version`` input is ignored.
+          The Python version already available in the environment is used as-is.
 
     required: false
     default: false
@@ -252,26 +251,12 @@ runs:
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
 
-    - name: "Check Python version matches expected version"
+    - uses: ansys/actions/_logging@main
       if: ${{ inputs.skip-python-setup == 'true' }}
-      shell: bash
-      env:
-        EXPECTED_VERSION: ${{ inputs.python-version }}
-      run: |
-        RAW_VERSION=$(python --version 2>&1)
-        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
-        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
-          echo "::error::No Python interpreter found on PATH."
-          exit 1
-        fi
-        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
-        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
-        # Compare only the specified number of parts to allow for flexibility in patch versions.
-        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
-        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
-          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
-          exit 1
-        fi
+      with:
+        level: "INFO"
+        message: >
+          Skipping Python setup to use system Python.
 
     # ------------------------------------------------------------------------
 

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -213,6 +213,17 @@ inputs:
     required: false
     type: string
 
+  skip-python-setup:
+    description: |
+      Whether to skip the Python setup step performed by
+      ``ansys/actions/_setup-python``. If ``true``, the setup step is skipped
+      and the Python version already available in the environment is used.
+      This is useful when a specific Python installation is already on the
+      ``PATH`` and the setup step would override it.
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -225,7 +236,8 @@ runs:
         persist-credentials: false
       if: ${{ inputs.checkout == 'true' }}
 
-    - name: "Set up Python"
+    - name: "Set up Python ${{ inputs.python-version }}"
+      if: ${{ inputs.skip-python-setup == 'false' }}
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -220,6 +220,13 @@ inputs:
       and the Python version already available in the environment is used.
       This is useful when a specific Python installation is already on the
       ``PATH`` and the setup step would override it.
+
+      .. warning::
+
+          The python version available in the environment must match the
+          version specified in the ``python-version`` input. If not, the
+          action will fail.
+
     required: false
     default: false
     type: boolean
@@ -244,6 +251,27 @@ runs:
         use-cache: ${{ inputs.use-python-cache }}
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
+
+    - name: "Check Python version matches expected version"
+      if: ${{ inputs.skip-python-setup == 'true' }}
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.python-version }}
+      run: |
+        RAW_VERSION=$(python --version 2>&1)
+        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
+        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
+          echo "::error::No Python interpreter found on PATH."
+          exit 1
+        fi
+        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
+        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
+        # Compare only the specified number of parts to allow for flexibility in patch versions.
+        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
+        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
+          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
+          exit 1
+        fi
 
     # ------------------------------------------------------------------------
 

--- a/doc/source/changelog/1310.added.md
+++ b/doc/source/changelog/1310.added.md
@@ -1,0 +1,1 @@
+Allow skipping python setup

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -142,9 +142,8 @@ inputs:
 
       .. warning::
 
-          The python version available in the environment must match the
-          version specified in the ``python-version`` input. If not, the
-          action will fail.
+          When this option is enabled, the ``python-version`` input is ignored.
+          The Python version already available in the environment is used as-is.
 
     required: false
     default: false
@@ -205,26 +204,12 @@ runs:
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
 
-    - name: "Check Python version matches expected version"
+    - uses: ansys/actions/_logging@main
       if: ${{ inputs.skip-python-setup == 'true' }}
-      shell: bash
-      env:
-        EXPECTED_VERSION: ${{ inputs.python-version }}
-      run: |
-        RAW_VERSION=$(python --version 2>&1)
-        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
-        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
-          echo "::error::No Python interpreter found on PATH."
-          exit 1
-        fi
-        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
-        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
-        # Compare only the specified number of parts to allow for flexibility in patch versions.
-        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
-        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
-          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
-          exit 1
-        fi
+      with:
+        level: "INFO"
+        message: >
+          Skipping Python setup to use system Python.
 
     # NOTE: Installation of poetry in a separate environment to the project to
     # avoid situations in which both poetry and the project have shared

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -132,6 +132,17 @@ inputs:
     required: false
     type: boolean
 
+  skip-python-setup:
+    description: |
+      Whether to skip the Python setup step performed by
+      ``ansys/actions/_setup-python``. If ``true``, the setup step is skipped
+      and the Python version already available in the environment is used.
+      This is useful when a specific Python installation is already on the
+      ``PATH`` and the setup step would override it.
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -178,7 +189,8 @@ runs:
         message: >
           Set up python to test.
 
-    - name: "Set up Python"
+    - name: "Set up Python ${{ inputs.python-version }}"
+      if: ${{ inputs.skip-python-setup == 'false' }}
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -139,6 +139,13 @@ inputs:
       and the Python version already available in the environment is used.
       This is useful when a specific Python installation is already on the
       ``PATH`` and the setup step would override it.
+
+      .. warning::
+
+          The python version available in the environment must match the
+          version specified in the ``python-version`` input. If not, the
+          action will fail.
+
     required: false
     default: false
     type: boolean
@@ -197,6 +204,27 @@ runs:
         use-cache: ${{ inputs.use-python-cache }}
         provision-uv: ${{ inputs.use-uv }}
         prune-uv-cache: ${{ inputs.use-python-cache != 'true' }}
+
+    - name: "Check Python version matches expected version"
+      if: ${{ inputs.skip-python-setup == 'true' }}
+      shell: bash
+      env:
+        EXPECTED_VERSION: ${{ inputs.python-version }}
+      run: |
+        RAW_VERSION=$(python --version 2>&1)
+        # Fail early if no usable Python (e.g. Windows Microsoft Store stub)
+        if [[ "${RAW_VERSION}" == "Python was not found;"* ]] || [[ -z "${RAW_VERSION}" ]]; then
+          echo "::error::No Python interpreter found on PATH."
+          exit 1
+        fi
+        ACTUAL_VERSION=$(echo "${RAW_VERSION}" | awk '{print $2}')
+        PART_COUNT=$(echo "${EXPECTED_VERSION}" | awk -F. '{print NF}')
+        # Compare only the specified number of parts to allow for flexibility in patch versions.
+        ACTUAL_PREFIX=$(echo "${ACTUAL_VERSION}" | cut -d. -f1-${PART_COUNT})
+        if [[ "${ACTUAL_PREFIX}" != "${EXPECTED_VERSION}" ]]; then
+          echo "::error::Python version mismatch. Expected ${EXPECTED_VERSION} but found ${ACTUAL_VERSION}."
+          exit 1
+        fi
 
     # NOTE: Installation of poetry in a separate environment to the project to
     # avoid situations in which both poetry and the project have shared


### PR DESCRIPTION
This pull request adds a skip-python-setup input to the affected composite actions. The default value is `false`, which leads to keeping the same behavior as before. When set to `true`:

- The _setup-python step is skipped entirely, leaving $GITHUB_PATH untouched.
- A validation step checks that the Python already on PATH matches the version specified in the python-version input (supports both major.minor and major.minor.micro precision), failing fast with a clear error message if there is a mismatch.

This provides flexibility for container-based environments with a pre-installed Python when the current implementation does not. As a matter of fact, the latest release of `ansys/actions` can't be used to build wheelhouse in a rocky container due to `glibc` incompatibilities, even if one does manually install python before calling `ansys/actions/build-wheelhouse`.

The affected actions are currently limited to `build-library`, `build-wheelhouse`, `doc-build` and `tests-pytest` as they are the ones most likely benefiting from it. The `build` ones would allow to build on specific environments, e.g. rocky; the `doc` and `tests` ones are used in some of our self-hosted runners.  