### PR TITLE
fix: update input tomli-version default value to empty string

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -83,7 +83,7 @@ inputs:
   tomli-version:  # TODO: Remove deprecated input in v12
     description: |
       Tomli version used for retrieving the towncrier directory.
-    default: '2.2.1'
+    default: ''
     required: false
     type: string
 

--- a/doc/source/changelog/1325.fixed.md
+++ b/doc/source/changelog/1325.fixed.md
@@ -1,0 +1,1 @@
+Update input tomli-version default value to empty string


### PR DESCRIPTION
That input value is not used in the action AND it is showing a warning which doesn't make much sense from the user perspective, see below

```
Warning: The ``tomli-version`` input is deprecated and will be removed in v12. This action now uses the ``tomlkit`` library instead. Please use the ``tomlkit-version`` input accordingly.
```

Changing the default value to `''` should remove the warning and have zero impact on users :)