### PR TITLE
chore!: removal of deprecated ``generate_release_notes`` input in the ``release-github`` action

### DIFF
--- a/doc/source/changelog/1348.breaking.md
+++ b/doc/source/changelog/1348.breaking.md
@@ -1,0 +1,1 @@
+Removal of deprecated \`\`generate_release_notes\`\` input in the \`\`release-github\`\` action

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -18,6 +18,10 @@ Version ``v11``
   Team at pyansys.core@ansys.com for enabling trusted publishing for your project and refer to
   :ref:`release_pypi_trusted_publisher` for setup details.
 
+- **Removal of deprecated input from release-github action:** The ``generate_release_notes`` input of the
+  ``release-github`` action was deprecated in ``v10`` and is completely removed starting with ``v11``.
+  Use the ``generate-release-notes`` parameter instead.
+
 Version ``v10.3``
 -----------------
 

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -160,13 +160,6 @@ inputs:
     required: false
     type: boolean
 
-  generate_release_notes:
-    description: |
-      Deprecated. Use the `generate-release-notes` input parameter.
-    default: false
-    required: false
-    type: boolean
-
   generate-release-notes:
     description: |
       Whether to automatically generate the name and body for this release.
@@ -228,14 +221,6 @@ runs:
         message: >
           The ``tomlkit-version`` and ``pypandoc-binary-version`` inputs are deprecated and will be
           removed in v12.
-
-    - uses: ansys/actions/_logging@main
-      if: ${{ inputs.generate_release_notes == 'true' }}
-      with:
-        level: "WARNING"
-        message: >
-          The use of the ``generate_release_notes`` parameter is deprecated and will be removed in
-          ansys/actions@v11. Please, use the new ``generate-release-notes`` parameter.
 
     # Only one of both can be true: generate-release-notes, changelog-release-notes
     - name: "Sanity check on release notes"
@@ -537,9 +522,7 @@ runs:
       if: inputs.dry-run == 'false'
       with:
         fail_on_unmatched_files: false
-        # TODO: remove the ``generate_release_notes`` parameter in ansys/actions@v11
-        # https://github.com/ansys/actions/issues/835
-        generate_release_notes: ${{ inputs.generate-release-notes }} || ${{ inputs.generate_release_notes }}
+        generate_release_notes: ${{ inputs.generate-release-notes }}
         body: ${{ env.RELEASE_NOTES_BODY }}
         repository: ${{ github.repository_owner }}/${{ env.REPO_NAME }}
         token: ${{ inputs.token }}


### PR DESCRIPTION
Closes #835.