### PR TITLE
feat: add uv lock check in build-library

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -26,7 +26,9 @@ name: |
 description: |
   Verifies if a Python library builds properly. As a result of a successful
   building process, wheel and source distribution artifacts are generated. This
-  action is expected to be used as an independent job.
+  action is expected to be used as an independent job. When a project contains
+  a uv lock file, it is also verified during the build process to ensure it is up to
+  date with the project dependencies.
 
   .. note::
 
@@ -226,6 +228,13 @@ runs:
       if: inputs.validate-build == 'true'
       run: |
         python -m twine check dist/*
+
+    - name: "Check if the uv lock file is up to date with respect to project dependencies (if it exists)"
+      if: inputs.use-uv == 'true' && hashFiles(format('{0}/uv.lock', inputs.working-directory)) != ''
+      shell: bash
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: uv lock --check --project "${WORKING_DIRECTORY}"
 
     - name: "Upload distribution artifacts to GitHub artifacts"
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/doc/source/changelog/1357.added.md
+++ b/doc/source/changelog/1357.added.md
@@ -1,0 +1,1 @@
+Add uv lock check in build-library


### PR DESCRIPTION
This PR enhances the build verification process for Python libraries by adding a check to ensure that the `uv.lock` file, if present, is up to date with the project's dependencies. This helps maintain consistency between the lock file and actual dependencies.

The idea if very open and could be rejected / updated to work with an input / ... Let me know if you think it make sense to add it here :)

Successful workflow here https://github.com/ansys/pyaedt-toolkits-common/actions/runs/27014823110/job/79727057353
Expected failing workflow here https://github.com/ansys/pyaedt-toolkits-common/actions/runs/27014432436/job/79725757899

The context of the failing workflow is the addition of `ansys-tools-common` to the main dependencies and the failure to remember about updating the lock file. The CI worked because the package was previously a transitive dependency so we ended up installing the package anyways but the lock file wasn't sync.