### PR TITLE
fix: allow multi colon in pr title

### DIFF
--- a/doc/source/changelog/1358.fixed.md
+++ b/doc/source/changelog/1358.fixed.md
@@ -1,0 +1,1 @@
+Allow multi colon in pr title

--- a/python-utils/parse_pr.py
+++ b/python-utils/parse_pr.py
@@ -99,8 +99,8 @@ def has_title_breaking_changes(pr_title: str) -> bool:
         True if the pull request title indicates a breaking change, False otherwise.
     """
     colon_count = pr_title.count(":")
-    if colon_count != 1:
-        raise ValueError(f"Expected exactly one ':', found {colon_count}")
+    if colon_count < 1:
+        raise ValueError(f"Expected at least one ':', found {colon_count}")
 
     colon_index = pr_title.index(":")
     exclam_index = pr_title.find("!")


### PR DESCRIPTION
As title says. Allowing multi colon when parsing PR title arises from dependabot's PR for pre-commit eco-system. Indeed, the title can be `build(pre-commit): bump https://github.com/astral-sh/ruff-pre-commit from v0.15.14 to 0.15.15`.

I checked https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/customizing-dependabot-prs and can't find another solution for this scenario :/