### PR TITLE
chore!: remove deprecated inputs

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -73,13 +73,6 @@ inputs:
     required: false
     type: string
 
-  toml-version: # TODO: Remove deprecated input in v11
-    description: |
-      Toml version used for retrieving the towncrier directory.
-    default: ''
-    required: false
-    type: string
-
   tomli-version:  # TODO: Remove deprecated input in v12
     description: |
       Tomli version used for retrieving the towncrier directory.
@@ -146,38 +139,25 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
-      if: inputs.toml-version != ''
-      with:
-        level: "ERROR"
-        message: >
-          With the adoption of dependency groups in PyAnsys packages, the ``toml`` library
-          is no longer used because it cannot parse ``pyproject.toml`` files where groups
-          include other groups. This action now uses the ``tomli`` library instead. If you
-          want to use a specific version of ``tomli``, please set the ``tomli-version``
-          input accordingly. The ``toml-version`` input will be removed in v11.
-
-    - uses: ansys/actions/_logging@main # Switch logging level to ERROR in v12
+    - uses: ansys/actions/_logging@main # TODO: Remove in v12
       if: inputs.use-conventional-commits != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           The ``use-conventional-commits`` input is deprecated and will be removed in v12.
           Please use the ``use-pull-request-title`` input instead.
 
-    - uses: ansys/actions/_logging@main # TODO: Switch logging level to ERROR in v11, remove in v12
+    - uses: ansys/actions/_logging@main # TODO: Remove in v12
       if: inputs.tomli-version != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           The ``tomli-version`` input is deprecated and will be removed in v12.
-          This action now uses the ``tomlkit`` library instead. Please use the
-          ``tomlkit-version`` input accordingly.
 
     - uses: ansys/actions/_logging@main
       if: inputs.towncrier-version != '' || inputs.tomlkit-version != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           The ``towncrier-version`` and ``tomlkit-version`` inputs are deprecated and will be
           removed in v12.

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -122,13 +122,6 @@ inputs:
     required: false
     type: string
 
-  toml-version: # TODO: Remove deprecated input in v11
-    description: |
-      Toml version used for retrieving the towncrier directory.
-    default: ''
-    required: false
-    type: string
-
   tomli-version:  # TODO: Remove deprecated input in v12
     description: |
       Tomli version used for retrieving the towncrier directory.
@@ -198,24 +191,16 @@ runs:
   using: "composite"
   steps:
     - uses: ansys/actions/_logging@main
-      if: inputs.toml-version != '' || inputs.tomli-version != ''
+      if: inputs.tomli-version != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
-          The ``toml-version`` and ``tomli-version`` inputs are deprecated. With the adoption
-          of dependency groups in PyAnsys packages, the ``toml`` library is no longer used
-          because it cannot parse ``pyproject.toml`` files where groups include other groups.
-          While ``tomli`` supports parsing dependency groups, it can lose a lot of information
-          during parsing, including formatting and comments, which can negatively impact
-          the behavior of some of our actions. To ensure consistent read/write operations and
-          preserve this information, this action now uses the ``tomlkit`` library instead. If you
-          want to use a specific version of ``tomlkit``, please set the ``tomlkit-version`` input
-          accordingly.
+          The ``tomli-version`` input is deprecated and will be removed in v12.
 
     - uses: ansys/actions/_logging@main
       if: inputs.towncrier-version != '' || inputs.tomlkit-version != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           The ``towncrier-version`` and ``tomlkit-version`` inputs are deprecated and will be
           removed in v12.

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -67,17 +67,10 @@ inputs:
     required: false
     type: string
 
-  toml-version: # TODO: Remove deprecated input in v11
-    description: |
-      Toml version used for retrieving the towncrier directory.
-    default: ''
-    required: false
-    type: string
-
   tomli-version:  # TODO: Remove deprecated input in v12
     description: |
       Tomli version used for retrieving the towncrier directory.
-    default: '2.2.1'
+    default: ''
     required: false
     type: string
 
@@ -116,30 +109,17 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
-      if: inputs.toml-version != ''
+    - uses: ansys/actions/_logging@main # TODO: Remove in v12
+      if: inputs.tomli-version != ''
       with:
         level: "ERROR"
         message: >
-          With the adoption of dependency groups in PyAnsys packages, the ``toml`` library
-          is no longer used because it cannot parse ``pyproject.toml`` files where groups
-          include other groups. This action now uses the ``tomli`` library instead. If you
-          want to use a specific version of ``tomli``, please set the ``tomli-version``
-          input accordingly. The ``toml-version`` input will be removed in v11.
-
-    - uses: ansys/actions/_logging@main # TODO: Switch logging level to ERROR in v11, remove in v12
-      if: inputs.tomli-version != ''
-      with:
-        level: "WARNING"
-        message: >
           The ``tomli-version`` input is deprecated and will be removed in v12.
-          This action now uses the ``tomlkit`` library instead. Please use the
-          ``tomlkit-version`` input accordingly.
 
     - uses: ansys/actions/_logging@main
       if: inputs.tomlkit-version != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           The ``tomlkit-version`` input is deprecated and will be removed in v12.
 

--- a/doc/source/changelog/1376.breaking.md
+++ b/doc/source/changelog/1376.breaking.md
@@ -1,0 +1,1 @@
+Remove deprecated inputs

--- a/hk-package-clean-except/action.yml
+++ b/hk-package-clean-except/action.yml
@@ -56,30 +56,10 @@ inputs:
     required: false
     default: ''
     type: string
-  python-version:  # TODO: Remove deprecated input in v11
-    description: 'DEPRECATED ARGUMENT. Desired Python version.'
-    default: ''
-    required: false
-    type: string
-  use-uv:  # TODO: Remove deprecated input in v11
-    description: |
-      DEPRECATED ARGUMENT. Whether to use uv as the default package manager instead of pip. Default value is ``''``.
-    default: ''
-    required: false
-    type: string
 
 runs:
   using: "composite"
   steps:
-
-    - uses: ansys/actions/_logging@main
-      if: inputs.python-version != '' || inputs.use-uv != ''
-      with:
-        level: "WARNING"
-        message: >
-          'The "python-version" and "use-uv" inputs are deprecated and will be
-          removed in future releases. This action uses a specific Python version set
-          up in a separate step.'
 
     - name: "Set up Python 3.14"
       uses: ansys/actions/_setup-python@main

--- a/hk-package-clean-untagged/action.yml
+++ b/hk-package-clean-untagged/action.yml
@@ -47,30 +47,10 @@ inputs:
     required: false
     default: ''
     type: string
-  python-version:  # TODO: Remove deprecated input in v11
-    description: 'DEPRECATED ARGUMENT. Desired Python version.'
-    default: ''
-    required: false
-    type: string
-  use-uv:  # TODO: Remove deprecated input in v11
-    description: |
-      DEPRECATED ARGUMENT. Whether to use uv as the default package manager instead of pip. Default value is ``''``.
-    default: ''
-    required: false
-    type: string
 
 runs:
   using: "composite"
   steps:
-
-    - uses: ansys/actions/_logging@main
-      if: inputs.python-version != '' || inputs.use-uv != ''
-      with:
-        level: "WARNING"
-        message: >
-          'The "python-version" and "use-uv" inputs are deprecated and will be
-          removed in future releases. This action uses a specific Python version set
-          up in a separate step.'
 
     - name: "Set up Python 3.14"
       uses: ansys/actions/_setup-python@main

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -97,13 +97,6 @@ inputs:
     default: false
     type: boolean
 
-  toml-version: # TODO: Remove deprecated input in v11
-    description: |
-      Toml version used for retrieving the towncrier directory.
-    default: ''
-    required: false
-    type: string
-
   tomli-version:  # TODO: Remove deprecated input in v12
     description: |
       Tomli version used for retrieving the towncrier directory.
@@ -194,30 +187,17 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
-      if: inputs.toml-version != ''
+    - uses: ansys/actions/_logging@main # TODO: Remove in v12
+      if: inputs.tomli-version != ''
       with:
         level: "ERROR"
         message: >
-          With the adoption of dependency groups in PyAnsys packages, the ``toml`` library
-          is no longer used because it cannot parse ``pyproject.toml`` files where groups
-          include other groups. This action now uses the ``tomli`` library instead. If you
-          want to use a specific version of ``tomli``, please set the ``tomli-version``
-          input accordingly. The ``toml-version`` input will be removed in v11.
-
-    - uses: ansys/actions/_logging@main # TODO: Switch logging level to ERROR in v11, remove in v12
-      if: inputs.tomli-version != ''
-      with:
-        level: "WARNING"
-        message: >
           The ``tomli-version`` input is deprecated and will be removed in v12.
-          This action now uses the ``tomlkit`` library instead. Please use the
-          ``tomlkit-version`` input accordingly.
 
     - uses: ansys/actions/_logging@main
       if: inputs.tomlkit-version != '' || inputs.pypandoc-binary-version != ''
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           The ``tomlkit-version`` and ``pypandoc-binary-version`` inputs are deprecated and will be
           removed in v12.

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -100,7 +100,7 @@ inputs:
   tomli-version:  # TODO: Remove deprecated input in v12
     description: |
       Tomli version used for retrieving the towncrier directory.
-    default: '2.2.1'
+    default: ''
     required: false
     type: string
 


### PR DESCRIPTION
As the title states. Closes #1338.