### PR TITLE
fix: pyansys geometry doc-build in tests

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -204,9 +204,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - name: windows-latest
-            container-image-tag: ghcr.io/ansys/geometry:core-windows-latest
-            dependencies: 'pandoc'
+          # - name: windows-latest
+          #   container-image-tag: ghcr.io/ansys/geometry:core-windows-latest
+          #   dependencies: 'pandoc'
           - name: ubuntu-latest
             container-image-tag: ghcr.io/ansys/geometry:core-linux-latest
             dependencies: 'pandoc texlive-xetex texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra texlive-science texlive-luatex lmodern latexmk'

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -206,8 +206,10 @@ jobs:
         os:
           - name: windows-latest
             container-image-tag: ghcr.io/ansys/geometry:core-windows-latest
+            dependencies: 'pandoc'
           - name: ubuntu-latest
             container-image-tag: ghcr.io/ansys/geometry:core-linux-latest
+            dependencies: 'pandoc texlive-xetex texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra texlive-science texlive-luatex lmodern latexmk'
       fail-fast: false
     env:
       ANSRV_GEO_IMAGE_DOCS_TAG: ${{ matrix.os.container-image-tag }}
@@ -253,10 +255,8 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           add-pdf-html-docs-as-assets: true
           needs-quarto: true
-          dependencies: 'pandoc'
-          # sphinxopts: '-j 1 -W --color'
-          # TODO: Re-enable warnings as errors after numpydoc issues are fixed
-          sphinxopts: '-j 1'
+          dependencies: ${{ matrix.os.dependencies }}
+          sphinxopts: '-j 1 -W --color'
           checkout: false
           uploaded-artifact-name-prefix: pyansys-geometry-documentation-${{ matrix.os.name }}
           skip-dependencies-cache: true

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -197,7 +197,9 @@ runs:
       shell: powershell
       env:
         NEEDED_DEPS: ${{ steps.collect-system-dependencies.outputs.NEEDED_DEPS }}
-      run: choco install $env:NEEDED_DEPS -y
+      run: |
+        $packages = $env:NEEDED_DEPS -split '\s+'
+        choco install $packages -y
 
     - name: Install MiKTeX and update PATH with MiKTeX binaries
       shell: powershell

--- a/doc/source/changelog/1380.fixed.md
+++ b/doc/source/changelog/1380.fixed.md
@@ -1,0 +1,1 @@
+Pyansys geometry doc-build in tests


### PR DESCRIPTION
As the title states.

Thanks to @RobPasMue, in the logs, we see:
```
! TeX capacity exceeded, sorry [input stack size=10000].
<inserted text> \the \everycr 
```
The most plausible cause I could see via searching for similar issues is https://github.com/sphinx-doc/sphinx/issues/7723. Some documentation related changes happened in geometry recently where new links were added, could that have been the cause? Either way, I have temporarily deactivated pyansys-geometry doc-build on windows. I can also look for more projects that are suitable for windows doc-build testing in the near future.

I have also used this opportunity to fix a bug where multiple space-separated dependencies are not being recognized as separate when passed to chocolatey, causing installation errors.