### PR TITLE
fix: uv build rejecting builds when cache dir is enclosed

### DIFF
--- a/_setup-python/action.yml
+++ b/_setup-python/action.yml
@@ -102,3 +102,4 @@ runs:
       with:
         enable-cache: ${{ inputs.use-cache }}
         prune-cache: ${{ inputs.prune-uv-cache }}
+        cache-local-path: ${{ runner.temp }}/.uv-cache

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -150,7 +150,7 @@ runs:
 
     - name: "Set up Python ${{ inputs.python-version }}"
       if: ${{ inputs.skip-python-setup == 'false' }}
-      uses: ansys/actions/_setup-python@fix/build-library #main
+      uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -150,7 +150,7 @@ runs:
 
     - name: "Set up Python ${{ inputs.python-version }}"
       if: ${{ inputs.skip-python-setup == 'false' }}
-      uses: ansys/actions/_setup-python@main
+      uses: ansys/actions/_setup-python@fix/build-library #main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}

--- a/doc/source/changelog/1387.fixed.md
+++ b/doc/source/changelog/1387.fixed.md
@@ -1,0 +1,1 @@
+Uv build rejecting builds when cache dir is enclosed


### PR DESCRIPTION
The latest release of uv included changes in https://github.com/astral-sh/uv/pull/19991, which results in `uv build` failing when .uv_cache is in the same directly as the project, which happens to be the default behavior (ansys/actions/build-library is the only action affected as far as I know).

Example failing run: https://github.com/ansys-internal/pyresultexplorer/actions/runs/28356750449/job/84003124496
Passing when tested with this branch: https://github.com/ansys-internal/pyresultexplorer/actions/runs/28358868176/job/84008446770?pr=113

FYI we need to patch v10 with this ASAP.