### PR TITLE
chore: prettytable dependency pinning

### DIFF
--- a/doc/source/changelog/1400.maintenance.md
+++ b/doc/source/changelog/1400.maintenance.md
@@ -1,0 +1,1 @@
+Prettytable dependency pinning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ build-wheelhouse = [
 ]
 check-licenses = [
     "pip-licenses<=5.6",
-    "prettytable<=3.18.0",
+    "prettytable<=3.18",
     "wcwidth<=0.9",
 ]
 check-vulnerabilities = [


### PR DESCRIPTION
I missed this before merging https://github.com/ansys/actions/pull/1395. I have also opened https://github.com/ansys/actions/pull/1401 to prevent this from happening in the future.