### PR TITLE
chore: ignore patch updates for uv package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       prefix: "build(uv)"
     labels:
       - "dependencies:requirements"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directories:

--- a/doc/source/changelog/1401.maintenance.md
+++ b/doc/source/changelog/1401.maintenance.md
@@ -1,0 +1,1 @@
+Ignore patch updates for uv package ecosystem


### PR DESCRIPTION
We do not want dependabot to change the pinned versions in **pyproject.toml** from `major.minor` to `major.minor.patch` (see [1](https://github.com/ansys/actions/pull/1395) and [2](https://github.com/ansys/actions/pull/1368) as examples). With the help of @SMoraisAnsys, we came across the configuration option proposed in this PR, which seems to address our concern.

The hope is that dependency resolution still takes place and patch updates of dependencies still happens for the lock file (and consequently the `requirements.txt` files). We will need to monitor this in the coming weeks.