### PR TITLE
chore: update release testing

### DIFF
--- a/.ci/ansys-actions-flit/pyproject.toml
+++ b/.ci/ansys-actions-flit/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<3.11"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -9,8 +9,7 @@ version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses flit as the build backend)"
 readme = "README.rst"
 requires-python = ">=3.12"
-license = "MIT"
-license-files = [ "LICENSE" ]
+license = { file = "LICENSE" }
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [
     { name = "PyAnsys developers", email = "pyansys.core@ansys.com" },

--- a/.ci/ansys-actions-flit/pyproject.toml
+++ b/.ci/ansys-actions-flit/pyproject.toml
@@ -10,7 +10,7 @@ description = "A demo library for testing Ansys actions (uses flit as the build 
 readme = "README.rst"
 requires-python = ">=3.12"
 license = "MIT"
-license-files = [ "LICENSE"]
+license-files = [ "LICENSE" ]
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [
     { name = "PyAnsys developers", email = "pyansys.core@ansys.com" },

--- a/.ci/ansys-actions-flit/pyproject.toml
+++ b/.ci/ansys-actions-flit/pyproject.toml
@@ -19,7 +19,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = ["importlib-metadata >=4.0"]

--- a/.ci/ansys-actions-flit/pyproject.toml
+++ b/.ci/ansys-actions-flit/pyproject.toml
@@ -8,8 +8,9 @@ name = "ansys-actions-flit"
 version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses flit as the build backend)"
 readme = "README.rst"
-requires-python = ">=3.10"
-license = { file = "LICENSE" }
+requires-python = ">=3.12"
+license = "MIT"
+license-files = [ "LICENSE" ]
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [
     { name = "PyAnsys developers", email = "pyansys.core@ansys.com" },

--- a/.ci/ansys-actions-flit/pyproject.toml
+++ b/.ci/ansys-actions-flit/pyproject.toml
@@ -9,7 +9,8 @@ version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses flit as the build backend)"
 readme = "README.rst"
 requires-python = ">=3.12"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = [ "LICENSE"]
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 maintainers = [
     { name = "PyAnsys developers", email = "pyansys.core@ansys.com" },

--- a/.ci/ansys-actions-poetry/pyproject.toml
+++ b/.ci/ansys-actions-poetry/pyproject.toml
@@ -9,13 +9,13 @@ version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses poetry as the build backend)"
 readme = "README.rst"
 license = "MIT"
+license-files = [ "LICENSE" ]
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.core@ansys.com>"]
 
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 packages = [{include = "ansys", from = "src"}]

--- a/.ci/ansys-actions-poetry/pyproject.toml
+++ b/.ci/ansys-actions-poetry/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-actions-poetry"
 version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses poetry as the build backend)"
 readme = "README.rst"
-license = { text = "MIT" }
+license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.core@ansys.com>"]
 

--- a/.ci/ansys-actions-poetry/pyproject.toml
+++ b/.ci/ansys-actions-poetry/pyproject.toml
@@ -8,8 +8,7 @@ name = "ansys-actions-poetry"
 version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses poetry as the build backend)"
 readme = "README.rst"
-license = "MIT"
-license-files = [ "LICENSE" ]
+license = { text = "MIT" }
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.core@ansys.com>"]
 

--- a/.ci/ansys-actions-poetry/pyproject.toml
+++ b/.ci/ansys-actions-poetry/pyproject.toml
@@ -9,6 +9,7 @@ version = "10.4.dev0"
 description = "A demo library for testing Ansys actions (uses poetry as the build backend)"
 readme = "README.rst"
 license = "MIT"
+license-files = [ "LICENSE" ]
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["PyAnsys developers <pyansys.core@ansys.com>"]
 
@@ -21,7 +22,7 @@ classifiers = [
 packages = [{include = "ansys", from = "src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.12"
 importlib-metadata = ">=4.0"
 
 [[tool.poetry.source]]

--- a/.ci/devpi/Dockerfile
+++ b/.ci/devpi/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir devpi-server devpi-client
+
+RUN addgroup --system --gid 1000 devpi \
+    && adduser --disabled-password --system --uid 1000 \
+               --home /data --shell /sbin/nologin \
+               --gid 1000 devpi
+
+ENV DEVPISERVER_SERVERDIR=/data
+
+EXPOSE 3141
+VOLUME /data
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod 755 /docker-entrypoint.sh
+
+USER devpi
+WORKDIR /data
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=12 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:3141/')" || exit 1
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/.ci/devpi/docker-compose.yml
+++ b/.ci/devpi/docker-compose.yml
@@ -1,3 +1,25 @@
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 services:
   devpi:
     build: .

--- a/.ci/devpi/docker-compose.yml
+++ b/.ci/devpi/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  devpi:
+    build: .
+    ports:
+      - "3141:3141"
+    environment:
+      DEVPI_PASSWORD: devpipass

--- a/.ci/devpi/docker-entrypoint.sh
+++ b/.ci/devpi/docker-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+DEVPI_PASSWORD="${DEVPI_PASSWORD:-devpipass}"
+SERVERDIR="${DEVPISERVER_SERVERDIR:-/data}"
+
+wait_for_server() {
+    local retries=30
+    until python -c "import urllib.request; urllib.request.urlopen('http://localhost:3141/')" 2>/dev/null; do
+        retries=$((retries - 1))
+        if [ "$retries" -le 0 ]; then
+            echo "ERROR: devpi-server did not start in time" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
+if [ ! -f "${SERVERDIR}/.serverversion" ]; then
+    echo "[INIT] Initializing devpi-server at ${SERVERDIR}..."
+    devpi-init --serverdir "${SERVERDIR}"
+
+    echo "[INIT] Starting server temporarily for user/index configuration..."
+    devpi-server --host 127.0.0.1 --port 3141 --serverdir "${SERVERDIR}" &
+    SERVER_PID=$!
+    wait_for_server
+
+    echo "[INIT] Configuring root user and public index..."
+    devpi use http://localhost:3141
+    devpi login root --password ''
+    devpi user -m root password="${DEVPI_PASSWORD}"
+    devpi index -y -c public
+    devpi logoff
+
+    echo "[INIT] Stopping temporary server..."
+    kill "${SERVER_PID}"
+    wait "${SERVER_PID}" 2>/dev/null || true
+    echo "[INIT] Initialization complete."
+fi
+
+echo "[RUN] Starting devpi-server..."
+exec devpi-server --host 0.0.0.0 --port 3141 --serverdir "${SERVERDIR}" --restrict-modify root

--- a/.github/workflows/ci_cd_pr_flit.yml
+++ b/.github/workflows/ci_cd_pr_flit.yml
@@ -113,13 +113,22 @@ jobs:
           checkout: false
 
   test-release-flit:
-    name: "Test releasing ansys-actions-flit package using trusted publishing"
+    name: "Test releasing ansys-actions-flit package to local devpi server"
     runs-on: ubuntu-latest
     needs: test-build-library-flit
     permissions:
-      id-token: write # Needed for trusted publishing OIDC
       contents: read
     steps:
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: "Start devpi server"
+      run: docker compose -f .ci/devpi/docker-compose.yml up -d --build
+
+    - name: "Wait for devpi server to be ready"
+      run: timeout 120 bash -c 'until curl -sf http://localhost:3141/; do sleep 2; done'
 
     - name: "Download distribution artifacts"
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -127,13 +136,17 @@ jobs:
         name: ${{ env.LIBRARY_NAME }}-artifacts
         path: dist
 
-    - name: "Upload artifacts to test PyPI using trusted publisher"
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-      with:
-        repository-url: "https://test.pypi.org/legacy/"
-        print-hash: true
-        skip-existing: true
-        verbose: true
+    - name: "Upload artifacts to devpi"
+      env:
+        TWINE_USERNAME: root
+        TWINE_PASSWORD: devpipass
+        TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
+      run: |
+        pip install twine
+        twine upload dist/*
+
+    - name: "Verify package is installable from devpi"
+      run: pip install --index-url http://localhost:3141/root/public/+simple/ --no-deps ${{ env.LIBRARY_NAME }}
 
   test-build-wheelhouse-flit-projects:
     name: "Test build-wheelhouse action for ${{ matrix.repository.name }} project on ${{ matrix.os }}"

--- a/.github/workflows/ci_cd_pr_flit.yml
+++ b/.github/workflows/ci_cd_pr_flit.yml
@@ -142,7 +142,7 @@ jobs:
         TWINE_PASSWORD: devpipass
         TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
       run: | # zizmor: ignore[use-trusted-publishing]
-        pip install twine
+        pip install twine packaging
         twine upload dist/*
 
     - name: "Verify package is installable from devpi"

--- a/.github/workflows/ci_cd_pr_flit.yml
+++ b/.github/workflows/ci_cd_pr_flit.yml
@@ -141,12 +141,14 @@ jobs:
         TWINE_USERNAME: root
         TWINE_PASSWORD: devpipass
         TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
-      run: |
+      run: | # zizmor: ignore[use-trusted-publishing]
         pip install twine
         twine upload dist/*
 
     - name: "Verify package is installable from devpi"
-      run: pip install --index-url http://localhost:3141/root/public/+simple/ --no-deps ${{ env.LIBRARY_NAME }}
+      env:
+        LIBRARY: ${{ env.LIBRARY_NAME }}
+      run: pip install --index-url http://localhost:3141/root/public/+simple/ --no-deps "${LIBRARY}"
 
   test-build-wheelhouse-flit-projects:
     name: "Test build-wheelhouse action for ${{ matrix.repository.name }} project on ${{ matrix.os }}"

--- a/.github/workflows/ci_cd_pr_flit.yml
+++ b/.github/workflows/ci_cd_pr_flit.yml
@@ -142,7 +142,7 @@ jobs:
         TWINE_PASSWORD: devpipass
         TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
       run: | # zizmor: ignore[use-trusted-publishing]
-        pip install twine packaging
+        pip install -U twine packaging
         twine upload dist/*
 
     - name: "Verify package is installable from devpi"

--- a/.github/workflows/ci_cd_pr_poetry.yml
+++ b/.github/workflows/ci_cd_pr_poetry.yml
@@ -143,7 +143,7 @@ jobs:
         TWINE_PASSWORD: devpipass
         TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
       run: | # zizmor: ignore[use-trusted-publishing]
-        pip install twine packaging
+        pip install -U twine packaging
         twine upload dist/*
 
     - name: "Verify package is installable from devpi"

--- a/.github/workflows/ci_cd_pr_poetry.yml
+++ b/.github/workflows/ci_cd_pr_poetry.yml
@@ -114,13 +114,22 @@ jobs:
           checkout: false
 
   test-release-poetry:
-    name: "Test releasing ansys-actions-poetry package using trusted publishing"
+    name: "Test releasing ansys-actions-poetry package to local devpi server"
     runs-on: ubuntu-latest
     needs: test-build-library-poetry
     permissions:
-      id-token: write # Needed for trusted publishing OIDC
       contents: read
     steps:
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: "Start devpi server"
+      run: docker compose -f .ci/devpi/docker-compose.yml up -d --build
+
+    - name: "Wait for devpi server to be ready"
+      run: timeout 120 bash -c 'until curl -sf http://localhost:3141/; do sleep 2; done'
 
     - name: "Download distribution artifacts"
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -128,13 +137,17 @@ jobs:
         name: ${{ env.LIBRARY_NAME }}-artifacts
         path: dist
 
-    - name: "Upload artifacts to test PyPI using trusted publisher"
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-      with:
-        repository-url: "https://test.pypi.org/legacy/"
-        print-hash: true
-        skip-existing: true
-        verbose: true
+    - name: "Upload artifacts to devpi"
+      env:
+        TWINE_USERNAME: root
+        TWINE_PASSWORD: devpipass
+        TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
+      run: |
+        pip install twine
+        twine upload dist/*
+
+    - name: "Verify package is installable from devpi"
+      run: pip install --index-url http://localhost:3141/root/public/+simple/ --no-deps ${{ env.LIBRARY_NAME }}
 
   test-build-wheelhouse-poetry-projects:
     name: "Test build-wheelhouse action for ${{ matrix.repository.name }} project on ${{ matrix.os }}"

--- a/.github/workflows/ci_cd_pr_poetry.yml
+++ b/.github/workflows/ci_cd_pr_poetry.yml
@@ -142,12 +142,14 @@ jobs:
         TWINE_USERNAME: root
         TWINE_PASSWORD: devpipass
         TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
-      run: |
+      run: | # zizmor: ignore[use-trusted-publishing]
         pip install twine
         twine upload dist/*
 
     - name: "Verify package is installable from devpi"
-      run: pip install --index-url http://localhost:3141/root/public/+simple/ --no-deps ${{ env.LIBRARY_NAME }}
+      env:
+        LIBRARY: ${{ env.LIBRARY_NAME }}
+      run: pip install --index-url http://localhost:3141/root/public/+simple/ --no-deps "${LIBRARY}"
 
   test-build-wheelhouse-poetry-projects:
     name: "Test build-wheelhouse action for ${{ matrix.repository.name }} project on ${{ matrix.os }}"

--- a/.github/workflows/ci_cd_pr_poetry.yml
+++ b/.github/workflows/ci_cd_pr_poetry.yml
@@ -143,7 +143,7 @@ jobs:
         TWINE_PASSWORD: devpipass
         TWINE_REPOSITORY_URL: http://localhost:3141/root/public/
       run: | # zizmor: ignore[use-trusted-publishing]
-        pip install twine
+        pip install twine packaging
         twine upload dist/*
 
     - name: "Verify package is installable from devpi"

--- a/doc/source/changelog/1409.maintenance.md
+++ b/doc/source/changelog/1409.maintenance.md
@@ -1,0 +1,1 @@
+Update release testing


### PR DESCRIPTION
Closes #1407 (see for full description of the issue this PR solves).

Summary of tasks completed:
  - [x] License metadata of test packages has been updated.
  - [x] A `devpi` directory has been added (to `.ci` directory), containing necessary docker files to start a devpi server. I decided to create our own files and not leverage [muccg/devpi](https://github.com/muccg/docker-devpi) because:
    - [x] The contents of the docker files in [muccg/devpi](https://github.com/muccg/docker-devpi) are quite outdated. The published image on ghcr is correspondingly old.
    - [x] The docker file contains extra setup that I consider unnecessary for our use case.
    - [x] The repo has been archived, so there is no way for things to get updated. Moreover, we are easily able to modify things by having our own files
  - [x] Updated the workflow files to leverage devpi for testing 