### PR TITLE
chore: update the handling of uv dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,6 @@ updates:
       prefix: "build(uv)"
     labels:
       - "dependencies:requirements"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directories:

--- a/.github/workflows/ci_cd_dependabot.yml
+++ b/.github/workflows/ci_cd_dependabot.yml
@@ -93,3 +93,58 @@ jobs:
             git commit -am "fix: update requirements files [skip ci]"
           fi
           git push
+
+  append-pr-note:
+    name: Append pyproject.toml note to dependabot PR
+    permissions:
+      contents: read
+      pull-requests: write # Needed to edit the dependabot PR body
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Append warning note to the dependabot PR body"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the PR number associated with the pushed dependabot branch.
+          PR_NUMBER="$(gh pr list --head "${BRANCH}" --state open --json number -q '.[0].number' || true)"
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "::warning::No open PR found for branch '${BRANCH}' yet; skipping PR body update."
+            exit 0
+          fi
+          echo "Found PR #${PR_NUMBER} for branch '${BRANCH}'."
+
+          # Hidden marker to prevent duplicate appends.
+          MARKER="<!-- ansys-actions:pyproject-note -->"
+
+          # Fetch the current PR body.
+          CURRENT_BODY="$(gh pr view "${PR_NUMBER}" --json body -q .body)"
+
+          if printf '%s' "${CURRENT_BODY}" | grep -qF "${MARKER}"; then
+            echo "Marker already present in PR #${PR_NUMBER} body; nothing to do."
+            exit 0
+          fi
+
+          # Build the new body: existing body + blank line + marked note block.
+          NEW_BODY_FILE="$(mktemp)"
+          {
+            printf '%s\n\n' "${CURRENT_BODY}"
+            printf '%s\n' "${MARKER}"
+            cat <<'EOF'
+          > [!WARNING]
+          > If this dependabot update includes any changes to the `pyproject.toml`, ensure the version specifiers in the `pyproject.toml` are reverted to a valid `major.minor` range by taking the following steps:
+          >   - Clone the branch locally.
+          >   - Update the pinned versions in the `pyproject.toml` as needed. For example, say dependabot proposes a change from "wcwidth<=0.7" to "wcwidth<=0.8.1", this must be updated to "wcwidth<=0.9". Another example is a change from "safety>=3.7,<4" to "safety>=3.8.0,<4", this must be updated to "safety>=3.8,<4". No changes should be made to the `requirement.txt` files.
+          >   - Run `uv lock` to update the lock file.
+          >   - Commit your changes to the PR and proceed to merge.
+          EOF
+            printf '%s\n' "<!-- /ansys-actions:pyproject-note -->"
+          } > "${NEW_BODY_FILE}"
+
+          # Update the PR body using --body-file to avoid shell escaping issues
+          # with backticks, angle brackets, and quoted version specifiers.
+          gh pr edit "${PR_NUMBER}" --body-file "${NEW_BODY_FILE}"
+          echo "Appended pyproject.toml warning note to PR #${PR_NUMBER}."

--- a/.github/workflows/ci_cd_dependabot.yml
+++ b/.github/workflows/ci_cd_dependabot.yml
@@ -137,9 +137,9 @@ jobs:
           > [!WARNING]
           > If this dependabot update includes any changes to the `pyproject.toml`, ensure the version specifiers in the `pyproject.toml` are reverted to a valid `major.minor` range by taking the following steps:
           >   - Clone the branch locally.
-          >   - Update the pinned versions in the `pyproject.toml` as needed. For example, say dependabot proposes a change from "wcwidth<=0.7" to "wcwidth<=0.8.1", this must be updated to "wcwidth<=0.9". Another example is a change from "safety>=3.7,<4" to "safety>=3.8.0,<4", this must be updated to "safety>=3.8,<4". No changes should be made to the `requirement.txt` files.
+          >   - Update any pinned versions modified by Dependabot in `pyproject.toml` to the appropriate `major.minor` version range. For example, if Dependabot changes `wcwidth<=0.7` to `wcwidth<=0.8.1`, it should be updated to `wcwidth<=0.9`. Likewise, if Dependabot changes `safety>=3.7,<4` to `safety>=3.8.0,<4`, it should be updated to `safety>=3.8,<4`. Do **not** modify any `requirement.txt` files.
           >   - Run `uv lock` to update the lock file.
-          >   - Commit your changes to the PR and proceed to merge.
+          >   - Commit the changes to this PR and proceed to merge.
           EOF
             printf '%s\n' "<!-- /ansys-actions:pyproject-note -->"
           } > "${NEW_BODY_FILE}"

--- a/doc/source/changelog/1425.maintenance.md
+++ b/doc/source/changelog/1425.maintenance.md
@@ -1,0 +1,1 @@
+Update the handling of uv dependabot updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ check-licenses = [
 ]
 check-vulnerabilities = [
     "bandit>=1.9,<2",
-    "click>=8.4.1,<9",
+    "click>=8.4,<9",
     "pygithub>=2.9,<3",
-    "safety>=3.8.1,<4",
+    "safety>=3.8,<4",
 ]
 code-style-pre-commit = [
     "pre-commit<=4.6",
@@ -51,13 +51,13 @@ doc-style = [
     "tomlkit<=0.15",
 ]
 hk-package-clean-except = [
-    "fastcore<=1.14.5",
-    "ghapi<=2.0.1",
+    "fastcore<=1.15",
+    "ghapi<=2.1",
     "packaging<=26.2",
 ]
 hk-package-clean-untagged = [
-    "fastcore<=1.14.5",
-    "ghapi<=2.0.1",
+    "fastcore<=1.15",
+    "ghapi<=2.1",
     "packaging<=26.2",
 ]
 release-github = [

--- a/uv.lock
+++ b/uv.lock
@@ -113,9 +113,9 @@ check-licenses = [
 ]
 check-vulnerabilities = [
     { name = "bandit", specifier = ">=1.9,<2" },
-    { name = "click", specifier = ">=8.4.1,<9" },
+    { name = "click", specifier = ">=8.4,<9" },
     { name = "pygithub", specifier = ">=2.9,<3" },
-    { name = "safety", specifier = ">=3.8.1,<4" },
+    { name = "safety", specifier = ">=3.8,<4" },
 ]
 code-style-pre-commit = [{ name = "pre-commit", specifier = "<=4.6" }]
 code-style-prek = [{ name = "prek", specifier = "<=0.5" }]
@@ -133,13 +133,13 @@ doc-style = [
     { name = "tomlkit", specifier = "<=0.15" },
 ]
 hk-package-clean-except = [
-    { name = "fastcore", specifier = "<=1.14.5" },
-    { name = "ghapi", specifier = "<=2.0.1" },
+    { name = "fastcore", specifier = "<=1.15" },
+    { name = "ghapi", specifier = "<=2.1" },
     { name = "packaging", specifier = "<=26.2" },
 ]
 hk-package-clean-untagged = [
-    { name = "fastcore", specifier = "<=1.14.5" },
-    { name = "ghapi", specifier = "<=2.0.1" },
+    { name = "fastcore", specifier = "<=1.15" },
+    { name = "ghapi", specifier = "<=2.1" },
     { name = "packaging", specifier = "<=26.2" },
 ]
 release-github = [


### PR DESCRIPTION
The changes made in #1401 did not work as expected, examples:
  - https://github.com/ansys/actions/pull/1419
  - https://github.com/ansys/actions/pull/1413
  - https://github.com/ansys/actions/pull/1420

So in this PR, I am:
  - [x] Reverting the changes made in #1401.
  - [x] Updating all the undesirable `pyproject.toml` changes that have been merged.
  - [x] Adding a job to `ci_cd_dependabot.yml` to add a note to the end of `uv` dependabot PR description so that we are reminded to verify any `pyproject.toml` changes in subsequent PRs before merging. The note will look [like this](https://github.com/ansys-internal/test-repo-moe/pull/57/#issue-4957265765). Already discussed this with @SMoraisAnsys as a fallback approach in the past.

We can also decide to stop worrying about restricting the bounds in the `pyproject.toml` altogether. We can then observe by how much the CI load would actually increase and then decide if we are fine with that.