### PR TITLE
fix: dependabot(uv) update issues

### DIFF
--- a/.github/workflows/ci_cd_dependabot.yml
+++ b/.github/workflows/ci_cd_dependabot.yml
@@ -72,7 +72,7 @@ jobs:
               echo "  Processing: $file_cleaned (group: $group_name)"
 
               # Run uv export command
-              uv export --format requirements.txt --group "$group_name" --output-file "$file_cleaned" --no-hashes
+              uv export --format requirements.txt --group "$group_name" --output-file "$file_cleaned" --no-hashes --no-dev
           done
 
       - name: Commit and push requirements files if changed

--- a/doc/source/changelog/1474.fixed.md
+++ b/doc/source/changelog/1474.fixed.md
@@ -1,0 +1,1 @@
+Dependabot(uv) update issues


### PR DESCRIPTION
Closes #1473.

The root cause was not adding `--no-dev` flag as I have done (uv automatically includes the dev group in every export unless explictly disabled), and the reason the issue is just revealing itself now (and not in the past) is because the dev dependency group was recently just added (in https://github.com/ansys/actions/pull/1427).