### PR TITLE
fix: update handling of `optional-dependencies-name` and `group-dependencies-name` in tests-pytest action

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -343,7 +343,7 @@ jobs:
   test-doc-build-pyaedt:
     name: "Test doc-build action for PyAEDT on ${{ matrix.os.name }}"
     runs-on: ${{ matrix.os.name }}
-    needs: doc-build
+    needs: doc-style
     permissions:
       contents: read
       packages: read # Needed to pull geometry container image
@@ -390,6 +390,103 @@ jobs:
           needs-quarto: false
           optional-dependencies-name: 'all'
           group-dependencies-name: 'doc'
+
+  test-tests-pytest-on-pyaedt:
+    name: "Test tests-pytest action on PyAEDT"
+    runs-on: ubuntu-latest
+    needs: code-style
+    steps:
+
+      - name: "Install Git and clone PyAEDT repository"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: ansys/pyaedt
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Clone ansys/actions into a different path"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          path: actions
+
+      - name: "Run tests with pytest for PyAEDT"
+        uses: ./actions/tests-pytest
+        with:
+          checkout: false
+          group-dependencies-name: tests
+          optional-dependencies-name: all
+          pytest-postargs: 'tests/unit/test_utils.py -vvv'
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          requires-xvfb: true
+
+  test-tests-pytest-on-pyansys-geometry:
+    name: "Test tests-pytest action on PyAnsys Geometry"
+    runs-on: ubuntu-latest
+    needs: code-style
+    permissions:
+      contents: read
+      packages: read # Needed to pull geometry container image
+    env:
+      ANSRV_GEO_IMAGE: ghcr.io/ansys/geometry
+      ANSRV_GEO_PORT: 700
+      ANSRV_GEO_LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
+      GEO_CONT_NAME: ans_geo
+    steps:
+
+      - name: "Install Git and clone pyansys-geometry repository"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: ansys/pyansys-geometry
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and launch geometry service
+        env:
+          FULL_IMAGE_NAME: "${{ env.ANSRV_GEO_IMAGE }}:core-linux-latest"
+          TRANSPORT_MODE_SELECTION: ${{ secrets.TRANSPORT_MODE_SELECTION }}
+        run: |
+          docker pull ${FULL_IMAGE_NAME}
+          docker run --detach --name ${GEO_CONT_NAME} -e LICENSE_SERVER=${ANSRV_GEO_LICENSE_SERVER} -p ${ANSRV_GEO_PORT}:50051 ${FULL_IMAGE_NAME} ${TRANSPORT_MODE_SELECTION}
+
+      - name: Copy test files into geometry service container
+        run: |
+          docker cp tests/integration/files/. ${GEO_CONT_NAME}:/test-files
+          echo "ANSYS_GEOMETRY_TEST_FILES=/test-files" >> $GITHUB_ENV
+
+      - name: "Clone ansys/actions into a different path"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          path: actions
+
+      - name: "Run tests with pytest for PyAnsys Geometry"
+        uses: ./actions/tests-pytest
+        env:
+          ALLOW_PLOTTING: true
+        with:
+          checkout: false
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          pytest-extra-args: "--use-tracker=no"
+          randomize: true
+          group-dependencies-name: tests
+
+      - name: Stop the Geometry service
+        if: always()
+        run: |
+          docker stop ${GEO_CONT_NAME}
+          docker logs ${GEO_CONT_NAME}
+          docker rm ${GEO_CONT_NAME}
 
   doc-deploy-pr:
     name: "Deploy PR documentation"

--- a/doc/source/changelog/1476.fixed.md
+++ b/doc/source/changelog/1476.fixed.md
@@ -1,0 +1,1 @@
+Update handling of \`optional-dependencies-name\` and \`group-dependencies-name\` in tests-pytest action

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -96,6 +96,25 @@ Version ``v11``
   Although backwards compatibility is maintained, you are advised to set one of the inputs explicitly to avoid
   future breaking changes.
 
+- **Changed default behavior of tests-pytest dependency inputs:** The ``tests-pytest`` action now mirrors the
+  ``doc-build`` behavior described above for the ``optional-dependencies-name`` and ``group-dependencies-name``
+  inputs. Previously, ``optional-dependencies-name`` defaulted to ``tests``, which caused failures for projects
+  that do not define a ``tests`` extra in ``pyproject.toml``.
+
+  The new behavior is:
+
+  - Both inputs now default to empty (``''``).
+  - If **neither** input is provided, the action defaults to ``optional-dependencies-name=tests`` (for backwards compatibility).
+  - If **only one** is provided, only that one is used.
+  - If **both** are provided, both are used (a warning is logged).
+
+  The requirements-file lookup remains driven by ``optional-dependencies-name``: the action still installs from
+  ``requirements/requirements_<optional-dependencies-name>.txt`` when that file exists.
+
+  For Poetry-based projects, ``optional-dependencies-name`` is now correctly forwarded as ``--extras`` and
+  ``group-dependencies-name`` as ``--with`` (previously ``optional-dependencies-name`` was misrouted through
+  ``--with`` and ``group-dependencies-name`` was ignored).
+
 - **Remove references to removed inputs from your workflows:** Search your workflows for references to
   the inputs listed in the preceding breaking changes section (``generate_release_notes`` on the ``release-github`` action,
   ``toml-version`` on the ``doc-*`` and ``release-github`` actions, and ``python-version`` / ``use-uv`` on the

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -98,22 +98,11 @@ Version ``v11``
 
 - **Changed default behavior of tests-pytest dependency inputs:** The ``tests-pytest`` action now mirrors the
   ``doc-build`` behavior described above for the ``optional-dependencies-name`` and ``group-dependencies-name``
-  inputs. Previously, ``optional-dependencies-name`` defaulted to ``tests``, which caused failures for projects
-  that do not define a ``tests`` extra in ``pyproject.toml``.
+  inputs. The important differences are:
 
-  The new behavior is:
-
-  - Both inputs now default to empty (``''``).
-  - If **neither** input is provided, the action defaults to ``optional-dependencies-name=tests`` (for backwards compatibility).
-  - If **only one** is provided, only that one is used.
-  - If **both** are provided, both are used (a warning is logged).
-
-  The requirements-file lookup remains driven by ``optional-dependencies-name``: the action still installs from
+  - The action defaults to ``optional-dependencies-name=tests`` (for backwards compatibility).
+  - The requirements-file lookup remains driven by ``optional-dependencies-name``: the action still installs from
   ``requirements/requirements_<optional-dependencies-name>.txt`` when that file exists.
-
-  For Poetry-based projects, ``optional-dependencies-name`` is now correctly forwarded as ``--extras`` and
-  ``group-dependencies-name`` as ``--with`` (previously ``optional-dependencies-name`` was misrouted through
-  ``--with`` and ``group-dependencies-name`` was ignored).
 
 - **Remove references to removed inputs from your workflows:** Search your workflows for references to
   the inputs listed in the preceding breaking changes section (``generate_release_notes`` on the ``release-github`` action,

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -102,7 +102,7 @@ Version ``v11``
 
   - The action defaults to ``optional-dependencies-name=tests`` (for backwards compatibility).
   - The requirements-file lookup remains driven by ``optional-dependencies-name``: the action still installs from
-  ``requirements/requirements_<optional-dependencies-name>.txt`` when that file exists.
+    ``requirements/requirements_<optional-dependencies-name>.txt`` when that file exists.
 
 - **Remove references to removed inputs from your workflows:** Search your workflows for references to
   the inputs listed in the preceding breaking changes section (``generate_release_notes`` on the ``release-github`` action,

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -100,12 +100,13 @@ inputs:
 
   optional-dependencies-name:
     description: |
-      Any valid install targets defined in the ``pyproject.toml`` file, or the suffix
-      of a requirement file. Multiple targets can be specified as a comma-separated
-      list. The associated dependencies are installed before running the tests.
-      The default value is ``'tests'``. Therefore, in case of a requirement file, the
-      default file is ``requirements/requirements_tests.txt``.
-    default: 'tests'
+      Any valid install targets/extras defined in the ``pyproject.toml`` file, or the
+      suffix of a requirement file. Multiple targets can be specified as a
+      comma-separated list (space-separated for poetry-based projects). The associated
+      dependencies are installed before running the tests. Default value is ``''``. If
+      neither this nor ``group-dependencies-name`` is provided, the action defaults to
+      ``tests``.
+    default: ''
     required: false
     type: string
 
@@ -113,8 +114,9 @@ inputs:
     description: |
       Any valid dependency groups defined in the ``pyproject.toml`` file. Multiple
       targets can be specified as a comma-separated list. The associated dependencies
-      are installed before running the tests.
-      The default value is ``''``.
+      are installed before running the tests. Default value is ``''``. If neither this
+      nor ``optional-dependencies-name`` is provided, the action defaults to using
+      ``optional-dependencies-name=tests``.
     default: ''
     required: false
     type: string
@@ -211,6 +213,31 @@ runs:
         message: >
           Skipping Python setup to use system Python.
 
+    # ------------------------------------------------------------------------
+
+    - name: "Resolve dependency inputs"
+      id: resolve-deps
+      shell: bash
+      env:
+        OPT_DEPS: ${{ inputs.optional-dependencies-name }}
+        GRP_DEPS: ${{ inputs.group-dependencies-name }}
+      run: |
+        if [[ -z "$OPT_DEPS" && -z "$GRP_DEPS" ]]; then
+          echo "resolved-optional=tests" >> $GITHUB_OUTPUT
+          echo "resolved-group=" >> $GITHUB_OUTPUT
+        else
+          echo "resolved-optional=$OPT_DEPS" >> $GITHUB_OUTPUT
+          echo "resolved-group=$GRP_DEPS" >> $GITHUB_OUTPUT
+        fi
+
+    - uses: ansys/actions/_logging@main
+      if: ${{ steps.resolve-deps.outputs.resolved-optional != '' && steps.resolve-deps.outputs.resolved-group != '' }}
+      with:
+        level: "WARNING"
+        message: >
+          Both 'optional-dependencies-name' and 'group-dependencies-name' are specified.
+          Both will be used for installation.
+
     # NOTE: Installation of poetry in a separate environment to the project to
     # avoid situations in which both poetry and the project have shared
     # dependencies with different version. This can lead to CICD failures. For
@@ -277,7 +304,7 @@ runs:
       id: check-exists-requirements-file
       shell: bash
       env:
-        OPTIONAL_DEPENDENCIES_NAME: ${{ inputs.optional-dependencies-name }}
+        OPTIONAL_DEPENDENCIES_NAME: ${{ steps.resolve-deps.outputs.resolved-optional }}
       run: |
         echo "EXISTS_TESTS_REQUIREMENTS=$(if [ -f requirements/requirements_${OPTIONAL_DEPENDENCIES_NAME}.txt ]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
 
@@ -343,7 +370,7 @@ runs:
       shell: bash
       if: steps.check-exists-requirements-file.outputs.EXISTS_TESTS_REQUIREMENTS == 'true'
       env:
-        OPTIONAL_DEPENDENCIES_NAME: ${{ inputs.optional-dependencies-name }}
+        OPTIONAL_DEPENDENCIES_NAME: ${{ steps.resolve-deps.outputs.resolved-optional }}
         ACTIVATE_VENV: ${{ steps.virtual-environment-activation-command.outputs.ACTIVATE_VENV }}
         USE_UV: ${{ inputs.use-uv }}
       run: |
@@ -360,30 +387,35 @@ runs:
       env:
         ACTIVATE_VENV: ${{ steps.virtual-environment-activation-command.outputs.ACTIVATE_VENV }}
         BUILD_BACKEND: ${{ steps.github-environment-variables.outputs.BUILD_BACKEND }}
-        GROUP_DEPENDENCIES_NAME: ${{ inputs.group-dependencies-name }}
-        OPTIONAL_DEPENDENCIES_NAME: ${{ inputs.optional-dependencies-name }}
+        GROUP_DEPENDENCIES_NAME: ${{ steps.resolve-deps.outputs.resolved-group }}
+        OPTIONAL_DEPENDENCIES_NAME: ${{ steps.resolve-deps.outputs.resolved-optional }}
         USE_UV_LOCKFILE: ${{ steps.auto-detect-uv-lockfile.outputs.USE_UV_LOCKFILE }}
       run: |
         $ACTIVATE_VENV
         if [[ "$BUILD_BACKEND" == 'poetry' ]]; then
-          poetry install --with "$OPTIONAL_DEPENDENCIES_NAME"
+          if [[ -n "${GROUP_DEPENDENCIES_NAME}" ]]; then
+            poetry install --with "${GROUP_DEPENDENCIES_NAME}" --extras "${OPTIONAL_DEPENDENCIES_NAME}"
+          else
+            poetry install --extras "${OPTIONAL_DEPENDENCIES_NAME}"
+          fi
         else
-          # Optional dependencies
-          optional_dependencies_flag=""
+          # Optional dependencies handling
+          extra_dependencies_flags=""
+          project_spec="."
           if [ -n "${OPTIONAL_DEPENDENCIES_NAME}" ]; then
             if [[ "${BUILD_BACKEND}" == 'uv' && "${USE_UV_LOCKFILE}" == 'true' ]]; then
               IFS=',' read -ra extras_list <<< "${OPTIONAL_DEPENDENCIES_NAME}"
               for extra in "${extras_list[@]}"; do
                 trimmed_extra="$(echo "${extra}" | xargs)"
                 if [[ -n "${trimmed_extra}" ]]; then
-                  optional_dependencies_flag="$optional_dependencies_flag --extra ${trimmed_extra}"
+                  extra_dependencies_flags="$extra_dependencies_flags --extra ${trimmed_extra}"
                 fi
               done
             else
-              optional_dependencies_flag="[${OPTIONAL_DEPENDENCIES_NAME}]"
+              project_spec=".[${OPTIONAL_DEPENDENCIES_NAME}]"
             fi
           fi
-          # Group dependencies
+          # Group dependencies handling
           group_dependencies_flag=""
           if [ -n "${GROUP_DEPENDENCIES_NAME}" ]; then
             IFS=',' read -ra group_list <<< "${GROUP_DEPENDENCIES_NAME}"
@@ -394,12 +426,12 @@ runs:
           # Install dependencies (potentially mix of optional and group)
           if [[ "${BUILD_BACKEND}" == 'uv' ]]; then
             if [[ "${USE_UV_LOCKFILE}" == 'true' ]]; then
-              uv sync --frozen --no-dev $group_dependencies_flag $optional_dependencies_flag
+              uv sync --frozen --no-dev $group_dependencies_flag $extra_dependencies_flags
             else
-              uv pip install $group_dependencies_flag .$optional_dependencies_flag
+              uv pip install $group_dependencies_flag $project_spec
             fi
           else
-            python -m pip install $group_dependencies_flag .$optional_dependencies_flag
+            python -m pip install $group_dependencies_flag $project_spec
           fi
         fi
 


### PR DESCRIPTION
Closes #1475.

This PR aligns how **ansys/actions/tests-pytest** handles `optional-dependencies-name` and `group-dependencies-name` inputs with how they are handled in **ansys/actions/doc-build** (see #1350).

I have also added two tests for tests-pytest (for PyAEDT and PyAnsys Geometry).